### PR TITLE
Alias bump2version as bumpversion.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
     long_description=long_description,
     entry_points={
         'console_scripts': [
+            'bumpversion = bumpversion:main',
             'bump2version = bumpversion:main',
         ]
     },


### PR DESCRIPTION
I can't imagine anyone who will install **bump2version** but will still want to use the original version of **bumpversion** (other than to compare the two). So even though we can allow people to install whichever version they want, how about we get **bump2version** to also alias itself to *bumpversion*?

When I installed it, I expected it to override bumpversion, not to sit alongside it - so out of habit, I invoked `bumpversion patch` and didn't get an annotated tag like I was expecting.