### PR TITLE
Add option to sign tags.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,124 @@ lib/
 __pycache__
 .cache
 dist
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+.static_storage/
+.media/
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+
+# Swap
+[._]*.s[a-v][a-z]
+[._]*.sw[a-p]
+[._]s[a-v][a-z]
+[._]sw[a-p]
+
+# Session
+Session.vim
+
+# Temporary
+.netrwhist
+*~
+
+# Auto-generated tag files
+tags

--- a/README.rst
+++ b/README.rst
@@ -132,6 +132,13 @@ General configuration is grouped in a ``[bumpversion]`` section.
 
   Also available on the command line as ``(--tag | --no-tag)``.
 
+``sign_tags = (True | False)``
+  **default:** False (`Don't sign tags`)
+
+  Whether to sign tags.
+
+  Also available on the command line as ``(--sign-tags | --no-sign-tags)``.
+
 ``tag_name =``
   **default:** ``v{new_version}``
 

--- a/bumpversion/__init__.py
+++ b/bumpversion/__init__.py
@@ -148,8 +148,10 @@ class Git(BaseVCS):
         subprocess.check_output(["git", "add", "--update", path])
 
     @classmethod
-    def tag(cls, name, message):
+    def tag(cls, sign, name, message):
         command = ["git", "tag", name]
+        if sign:
+            command += ['-s']
         if message:
             command += ['--message', message]
         subprocess.check_output(command)
@@ -183,7 +185,7 @@ class Mercurial(BaseVCS):
         pass
 
     @classmethod
-    def tag(cls, name, message):
+    def tag(cls, sign, name, message):
         command = ["hg", "tag", name]
         if message:
             command += ['--message', message]
@@ -782,6 +784,12 @@ def main(original_args=None):
     taggroup.add_argument('--no-tag', action='store_false', dest="tag",
                           help='Do not create a tag in version control', default=argparse.SUPPRESS)
 
+    signtagsgroup = parser3.add_mutually_exclusive_group()
+    signtagsgroup.add_argument('--sign-tags', action='store_true', dest="sign_tags",
+                          help='Sign tags if created', default=defaults.get("sign_tags", False))
+    signtagsgroup.add_argument('--no-sign-tags', action='store_false', dest="sign_tags",
+                          help='Do not sign tags if created', default=argparse.SUPPRESS)
+
     parser3.add_argument('--tag-name', metavar='TAG_NAME',
                          help='Tag name (only works with --tag)',
                          default=defaults.get('tag_name', 'v{new_version}'))
@@ -921,14 +929,16 @@ def main(original_args=None):
     if do_commit:
         vcs.commit(message=commit_message)
 
+    sign_tags = args.sign_tags
     tag_name = args.tag_name.format(**vcs_context)
     tag_message = args.tag_message.format(**vcs_context)
-    logger.info("{} '{}' {} in {}".format(
+    logger.info("{} '{}' {} in {} and {}".format(
         "Would tag" if not do_tag else "Tagging",
         tag_name,
         "with message '{}'".format(tag_message) if tag_message else "without message",
-        vcs.__name__
+        vcs.__name__,
+        "signing" if sign_tags else "not signing"
     ))
 
     if do_tag:
-        vcs.tag(tag_name, tag_message)
+        vcs.tag(sign_tags, tag_name, tag_message)

--- a/bumpversion/__init__.py
+++ b/bumpversion/__init__.py
@@ -187,6 +187,10 @@ class Mercurial(BaseVCS):
     @classmethod
     def tag(cls, sign, name, message):
         command = ["hg", "tag", name]
+        if sign:
+            raise MercurialDoesNotSupportSignedTagsException(
+                'Mercurial does not support signed tags.'
+            )
         if message:
             command += ['--message', message]
         subprocess.check_output(command)
@@ -298,6 +302,10 @@ class MissingValueForSerializationException(Exception):
         self.message = message
 
 class WorkingDirectoryIsDirtyException(Exception):
+    def __init__(self, message):
+        self.message = message
+
+class MercurialDoesNotSupportSignedTagsException(Exception):
     def __init__(self, message):
         self.message = message
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -78,6 +78,7 @@ EXPECTED_OPTIONS = """
 --new-version VERSION
 [--commit | --no-commit]
 [--tag | --no-tag]
+[--sign-tags | --no-sign-tags]
 [--tag-name TAG_NAME]
 [--tag-message TAG_MESSAGE]
 [--message COMMIT_MSG]
@@ -119,6 +120,8 @@ optional arguments:
   --no-commit           Do not commit to version control
   --tag                 Create a tag in version control (default: False)
   --no-tag              Do not create a tag in version control
+  --sign-tags           Sign tags if created (default: False)
+  --no-sign-tags        Do not sign tags if created
   --tag-name TAG_NAME   Tag name (only works with --tag) (default:
                         v{new_version})
   --tag-message TAG_MESSAGE


### PR DESCRIPTION
Also added standard `.gitignore` files for Python and vim.

The test for Python 3.3 does not pass, but that appears to be because of an upstream issue checking out a required package.

A test to check that signatures are actually made has not been written, but it has been verified manually. I can add a test later, but it is a bit involved (it would require adding `gpg` to the `Dockerfile` and generating a signature in the test setup) and I do not currently have time for that.

Closes GH-5