### PR TITLE
Added error checking for version part argument.

### DIFF
--- a/bumpversion/__init__.py
+++ b/bumpversion/__init__.py
@@ -538,6 +538,10 @@ def main(original_args=None):
       sys.argv[1:] if original_args is None else original_args
     )
 
+    if positionals[0] not in ('major', 'minor', 'patch'):
+        print("ERROR: Must provide a valid version part: 'major', 'minor', or 'patch'")
+        return 1
+
     if len(positionals[1:]) > 2:
         warnings.warn("Giving multiple files on the command line will be deprecated, please use [bumpversion:file:...] in a config file.", PendingDeprecationWarning)
 
@@ -824,7 +828,7 @@ def main(original_args=None):
 
     if args.dry_run:
         logger.info("Dry run active, won't touch any files.")
-    
+
     if args.new_version:
         new_version = vc.parse(args.new_version)
 


### PR DESCRIPTION
In issue [#118](https://github.com/peritus/bumpversion/issues/118) of the original bumpversion repo, I reported an error regarding what happens when the user passes in an unknown version part. e.g. `bumpversion bugfix` instead of `bumpversion patch`. 

The existing code not only accepts this unknown argument value, but then goes on to *corrupt the repo* by doing the wrong thing, in multiple different ways.

This PR adds a simple error check to ensure that an invalid version part name cannot be sent into the code.