### PR TITLE
Log command output during bumpversion failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,20 @@ FROM themattrix/tox-base
 
 RUN apt-get update && apt-get install -y git-core mercurial
 
+# Update pyenv for access to newer Python releases.
+RUN cd /.pyenv \
+    && git fetch \
+    && git checkout v1.2.3
+
+ENV PYPY_VERSION=pypy2.7-5.10.0 \
+    PYPY3_VERSION=pypy3.5-5.10.1
+
 # install a newer version op pypy and pypy3 that doesn't have troubles
-RUN pyenv install pypy-5.6.0
-RUN pyenv install pypy3.3-5.5-alpha
+RUN pyenv install "$PYPY_VERSION"
+RUN pyenv install "$PYPY3_VERSION"
 
 # only install certain versions for tox to use
-RUN pyenv global system 2.7.13 3.4.5 3.5.2 3.6.0 pypy-5.6.0 pypy3.3-5.5-alpha
+RUN pyenv global system 2.7.13 3.4.5 3.5.2 3.6.0 "$PYPY_VERSION" "$PYPY3_VERSION"
 
 RUN git config --global user.email "bumpversion_test@example.org"
 RUN git config --global user.name "Bumpversion Test"

--- a/bumpversion/__init__.py
+++ b/bumpversion/__init__.py
@@ -73,7 +73,15 @@ class BaseVCS(object):
         f.close()
         env = os.environ.copy()
         env['HGENCODING'] = 'utf-8'
-        subprocess.check_output(cls._COMMIT_COMMAND + [f.name], env=env)
+        try:
+            subprocess.check_output(cls._COMMIT_COMMAND + [f.name], env=env)
+        except subprocess.CalledProcessError as exc:
+            err_msg = "Failed to run {}: return code {}, output: {}".format(
+                exc.cmd,
+                exc.returncode,
+                exc.output)
+            logger.exception(err_msg)
+            raise exc
         os.unlink(f.name)
 
     @classmethod

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist = py27, py27-configparser, py34, py35, py36, pypy, pypy3
 [testenv]
 passenv = HOME
 deps=
-  pytest
+  pytest>=3.4.0
   mock
 commands=
   py.test [] tests


### PR DESCRIPTION
To assist in debugging this bubbles up the command and output
in a log message during a `bumpversion` failure.

The pypy builds are updated to gain access to the `caplog` fixture
present in pytest 3.3+.  The project didn't list Python 3.2 as
supported, so I figured this would be harmless.