### PR TITLE
Read README as utf-8 text and set the content_type to text/markdown

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,14 @@
-import re
+import io
+import os
 from setuptools import setup
 
 description = 'Version-bump your software with a single command!'
 
-long_description = re.sub(
-  "\`(.*)\<#.*\>\`\_",
-  r"\1",
-  str(open('README.md', 'rb').read()).replace(description, '')
-)
+# Import the README and use it as the long-description.
+# This requires 'README.md' to be present in MANIFEST.in.
+here = os.path.abspath(os.path.dirname(__file__))
+with io.open(os.path.join(here, 'README.md'), encoding='utf-8') as f:
+    long_description = '\n' + f.read()
 
 setup(
     name='bump2version',

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
     packages=['bumpversion'],
     description=description,
     long_description=long_description,
+    long_description_content_type='text/markdown',
     entry_points={
         'console_scripts': [
             'bumpversion = bumpversion:main',


### PR DESCRIPTION
This is an improvement on #24 and fixes #17.

The generated wheel file contains the correct content_type and 'README' content.