### PR TITLE
Bugfix issue 22 new version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,6 +105,8 @@ venv.bak/
 .spyderproject
 .spyproject
 
+.idea
+
 # Rope project settings
 .ropeproject
 
@@ -129,3 +131,4 @@ Session.vim
 
 # Auto-generated tag files
 tags
+.pytest_cache

--- a/README.md
+++ b/README.md
@@ -383,6 +383,9 @@ bump2version is licensed under the MIT License - see the LICENSE.rst file for de
 ## Changes
 
 **unreleased**
+
+- If --new-version is specified, do not expect a `part` positional argument.
+
 **v0.5.9-dev**
 
 **v0.5.8**

--- a/bumpversion/__init__.py
+++ b/bumpversion/__init__.py
@@ -822,8 +822,13 @@ def main(original_args=None):
         assert defaults['files'] != None
         file_names = defaults['files'].split(' ')
 
-    parser3.add_argument('part',
-                         help='Part of the version to be bumped.')
+    if '--new-version' not in remaining_argv:
+        parser3.add_argument('part',
+                             help='Part of the version to be bumped.')
+        first_file_index = 1
+    else:
+        first_file_index = 0
+
     parser3.add_argument('files', metavar='file',
                          nargs='*',
                          help='Files to change', default=file_names)
@@ -838,7 +843,8 @@ def main(original_args=None):
 
     logger.info("New version will be '{}'".format(args.new_version))
 
-    file_names = file_names or positionals[1:]
+
+    file_names = file_names or positionals[first_file_index:]
 
     for file_name in file_names:
         files.append(ConfiguredFile(file_name, vc))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -213,14 +213,14 @@ def test_missing_explicit_config_file(tmpdir):
 def test_simple_replacement(tmpdir):
     tmpdir.join("VERSION").write("1.2.0")
     tmpdir.chdir()
-    main(shlex_split("patch --current-version 1.2.0 --new-version 1.2.1 VERSION"))
+    main(shlex_split("--current-version 1.2.0 --new-version 1.2.1 VERSION"))
     assert "1.2.1" == tmpdir.join("VERSION").read()
 
 
 def test_simple_replacement_in_utf8_file(tmpdir):
     tmpdir.join("VERSION").write("Kröt1.3.0".encode('utf-8'), 'wb')
     tmpdir.chdir()
-    main(shlex_split("patch --current-version 1.3.0 --new-version 1.3.1 VERSION"))
+    main(shlex_split("--current-version 1.3.0 --new-version 1.3.1 VERSION"))
     out = tmpdir.join("VERSION").read('rb')
     assert "'Kr\\xc3\\xb6t1.3.1'" in repr(out)
 
@@ -672,7 +672,7 @@ def test_override_vcs_current_version(tmpdir, vcs):
 def test_nonexisting_file(tmpdir):
     tmpdir.chdir()
     with pytest.raises(IOError):
-        main(shlex_split("patch --current-version 1.2.0 --new-version 1.2.1 doesnotexist.txt"))
+        main(shlex_split("--current-version 1.2.0 --new-version 1.2.1 doesnotexist.txt"))
 
 
 def test_nonexisting_file(tmpdir):
@@ -1012,11 +1012,12 @@ def test_log_no_config_file_info_message(tmpdir, capsys):
 
     assert actual_log == EXPECTED_LOG
 
+
 def test_log_parse_doesnt_parse_current_version(tmpdir):
     tmpdir.chdir()
 
     with mock.patch("bumpversion.logger") as logger:
-        main(['--parse', 'xxx', '--current-version', '12', '--new-version', '13', 'patch'])
+        main(['--parse', 'xxx', '--current-version', '12', '--new-version', '13'])
 
     actual_log ="\n".join(_mock_calls_to_string(logger)[4:])
 
@@ -1042,7 +1043,7 @@ def test_log_invalid_regex_exit(tmpdir):
 
     with pytest.raises(SystemExit):
         with mock.patch("bumpversion.logger") as logger:
-            main(['--parse', '*kittens*', '--current-version', '12', '--new-version', '13', 'patch'])
+            main(['--parse', '*kittens*', '--current-version', '12', '--new-version', '13'])
 
     actual_log ="\n".join(_mock_calls_to_string(logger)[4:])
 
@@ -1931,7 +1932,7 @@ def test_regression_new_version_cli_in_files(tmpdir, capsys):
         commit = true
         """).strip())
 
-    main("patch --allow-dirty --verbose --new-version 0.9.3".split(" "))
+    main("--allow-dirty --verbose --new-version 0.9.3".split(" "))
 
     assert "__version__ = '0.9.3'" == tmpdir.join("myp___init__.py").read()
     assert "current_version = 0.9.3" in tmpdir.join(".bumpversion.cfg").read()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -21,10 +21,14 @@ import bumpversion
 from bumpversion import main, DESCRIPTION, WorkingDirectoryIsDirtyException, \
     split_args_in_optional_and_positional
 
+
 def _get_subprocess_env():
     env = os.environ.copy()
-    env['HGENCODING'] = 'utf-8'
+    # In python2 cast to str from unicode (note the future import).
+    # In python3 does nothing.
+    env['HGENCODING'] = str('utf-8')
     return env
+
 SUBPROCESS_ENV = _get_subprocess_env()
 
 call = partial(subprocess.call, env=SUBPROCESS_ENV)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals, print_function
+from __future__ import print_function
 
 import os
 import pytest

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import print_function
+from __future__ import unicode_literals, print_function
 
 import os
 import pytest


### PR DESCRIPTION
This addresses [`part` should not be required if supplying `--new-version` #22](https://github.com/c4urself/bump2version/issues/22).

Notice:

- it is backwardly incompatible, since the bug is with the command line API not the implementation of the API: this might merit a 0.6.0 version number.
- the tests change to reflect the change in API
- the implementation is short and direct but somewhat dirty, inspecting the argument list for `--new-version` directly. I find the cascade of `ArgumentParser`s unattractive, and this fix makes it marginally worse in my view.


Fixes #22 
