### PR TITLE
Add interpolation when reading setup.cfg.

### DIFF
--- a/bumpversion/__init__.py
+++ b/bumpversion/__init__.py
@@ -10,8 +10,10 @@ except ImportError:
     from ConfigParser import RawConfigParser, SafeConfigParser as ConfigParser, NoOptionError
 
 try:
+    # Python 2
     from StringIO import StringIO
 except:
+    # Python 3
     from io import StringIO
 
 import argparse

--- a/bumpversion/__init__.py
+++ b/bumpversion/__init__.py
@@ -3,8 +3,10 @@
 from __future__ import unicode_literals
 
 try:
+    # Python 3 or pip-installed "configparser" on Python 2
     from configparser import RawConfigParser, ConfigParser, NoOptionError
 except ImportError:
+    # On Py2, "SafeConfigParser" is the same as "ConfigParser" on Py3
     from ConfigParser import RawConfigParser, SafeConfigParser as ConfigParser, NoOptionError
 
 try:

--- a/bumpversion/__init__.py
+++ b/bumpversion/__init__.py
@@ -12,7 +12,7 @@ except ImportError:
 try:
     # Python 2
     from StringIO import StringIO
-except:
+except ImportError:
     # Python 3
     from io import StringIO
 

--- a/bumpversion/__init__.py
+++ b/bumpversion/__init__.py
@@ -3,9 +3,9 @@
 from __future__ import unicode_literals
 
 try:
-    from configparser import RawConfigParser, NoOptionError
+    from configparser import RawConfigParser, ConfigParser, NoOptionError
 except ImportError:
-    from ConfigParser import RawConfigParser, NoOptionError
+    from ConfigParser import RawConfigParser, SafeConfigParser as ConfigParser, NoOptionError
 
 try:
     from StringIO import StringIO
@@ -614,13 +614,6 @@ def main(original_args=None):
     if 'current_version' in vcs_info:
         defaults['current_version'] = vcs_info['current_version']
 
-    config = RawConfigParser('')
-
-    # don't transform keys to lowercase (which would be the default)
-    config.optionxform = lambda option: option
-
-    config.add_section('bumpversion')
-
     explicit_config = hasattr(known_args, 'config_file')
 
     if explicit_config:
@@ -630,6 +623,17 @@ def main(original_args=None):
         config_file = 'setup.cfg'
     else:
         config_file = '.bumpversion.cfg'
+
+    # setup.cfg supports interpolation - for compatibility we must do the same.
+    if os.path.basename(config_file) == 'setup.cfg':
+        config = ConfigParser('')
+    else:
+        config = RawConfigParser('')
+
+    # don't transform keys to lowercase (which would be the default)
+    config.optionxform = lambda option: option
+
+    config.add_section('bumpversion')
 
     config_file_exists = os.path.exists(config_file)
 


### PR DESCRIPTION
Setuptools uses the default ConfigParser object when reading
setup.cfg which does interpolation. To be consistent with that format
bumpversion must do the same.

Fixes #21.