### PR TITLE
Windows behavior fixed, with appveyor tests passing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,6 +105,8 @@ venv.bak/
 .spyderproject
 .spyproject
 
+.idea
+
 # Rope project settings
 .ropeproject
 
@@ -129,3 +131,4 @@ Session.vim
 
 # Auto-generated tag files
 tags
+.pytest_cache

--- a/bumpversion/__init__.py
+++ b/bumpversion/__init__.py
@@ -819,12 +819,17 @@ def main(original_args=None):
                          help='Tag name (only works with --tag)',
                          default=defaults.get('tag_name', 'v{new_version}'))
 
+    if platform.system() == "Windows" and sys.version_info[0] == 3:
+        default_message = 'Bump version: {current_version} to {new_version}'
+    else:
+        default_message = 'Bump version: {current_version} → {new_version}'
+
     parser3.add_argument('--tag-message', metavar='TAG_MESSAGE', dest='tag_message',
-                         help='Tag message', default=defaults.get('tag_message', 'Bump version: {current_version} → {new_version}'))
+                         help='Tag message', default=defaults.get('tag_message', default_message))
 
     parser3.add_argument('--message', '-m', metavar='COMMIT_MSG',
                          help='Commit message',
-                         default=defaults.get('message', 'Bump version: {current_version} → {new_version}'))
+                         default=defaults.get('message', default_message))
 
     file_names = []
     if 'files' in defaults:

--- a/bumpversion/__init__.py
+++ b/bumpversion/__init__.py
@@ -233,12 +233,12 @@ class ConfiguredFile(object):
         assert False, msg
 
     def contains(self, search):
-        with io.open(self.path, 'rb') as f:
+        with io.open(self.path, 'rt', encoding='utf-8') as f:
             search_lines = search.splitlines()
             lookbehind = []
 
             for lineno, line in enumerate(f.readlines()):
-                lookbehind.append(line.decode('utf-8').rstrip("\n"))
+                lookbehind.append(line.rstrip("\n"))
 
                 if len(lookbehind) > len(search_lines):
                     lookbehind = lookbehind[1:]
@@ -247,14 +247,14 @@ class ConfiguredFile(object):
                    search_lines[-1] in lookbehind[-1] and
                    search_lines[1:-1] == lookbehind[1:-1]):
                     logger.info("Found '{}' in {} at line {}: {}".format(
-                        search, self.path, lineno - (len(lookbehind) - 1), line.decode('utf-8').rstrip()))
+                        search, self.path, lineno - (len(lookbehind) - 1), line.rstrip()))
                     return True
         return False
 
     def replace(self, current_version, new_version, context, dry_run):
 
-        with io.open(self.path, 'rb') as f:
-            file_content_before = f.read().decode('utf-8')
+        with io.open(self.path, 'rt', encoding='utf-8') as f:
+            file_content_before = f.read()
 
         context['current_version'] = self._versionconfig.serialize(current_version, context)
         context['new_version'] = self._versionconfig.serialize(new_version, context)
@@ -292,8 +292,8 @@ class ConfiguredFile(object):
             ))
 
         if not dry_run:
-            with io.open(self.path, 'wb') as f:
-                f.write(file_content_after.encode('utf-8'))
+            with io.open(self.path, 'wt', encoding='utf-8') as f:
+                f.write(file_content_after)
 
     def __str__(self):
         return self.path
@@ -892,8 +892,8 @@ def main(original_args=None):
         logger.info(new_config.getvalue())
 
         if write_to_config_file:
-            with io.open(config_file, 'wb') as f:
-                f.write(new_config.getvalue().encode('utf-8'))
+            with io.open(config_file, 'wt', encoding='utf-8') as f:
+                f.write(new_config.getvalue())
 
     except UnicodeEncodeError:
         warnings.warn(

--- a/bumpversion/__init__.py
+++ b/bumpversion/__init__.py
@@ -811,11 +811,11 @@ def main(original_args=None):
                          default=defaults.get('tag_name', 'v{new_version}'))
 
     parser3.add_argument('--tag-message', metavar='TAG_MESSAGE', dest='tag_message',
-                         help='Tag message', default=defaults.get('tag_message', 'Bump version: {current_version} to {new_version}'))
+                         help='Tag message', default=defaults.get('tag_message', 'Bump version: {current_version} → {new_version}'))
 
     parser3.add_argument('--message', '-m', metavar='COMMIT_MSG',
                          help='Commit message',
-                         default=defaults.get('message', 'Bump version: {current_version} to {new_version}'))
+                         default=defaults.get('message', 'Bump version: {current_version} → {new_version}'))
 
     file_names = []
     if 'files' in defaults:

--- a/bumpversion/__init__.py
+++ b/bumpversion/__init__.py
@@ -819,17 +819,12 @@ def main(original_args=None):
                          help='Tag name (only works with --tag)',
                          default=defaults.get('tag_name', 'v{new_version}'))
 
-    if platform.system() == "Windows" and sys.version_info[0] == 3:
-        default_message = 'Bump version: {current_version} to {new_version}'
-    else:
-        default_message = 'Bump version: {current_version} → {new_version}'
-
     parser3.add_argument('--tag-message', metavar='TAG_MESSAGE', dest='tag_message',
-                         help='Tag message', default=defaults.get('tag_message', default_message))
+                         help='Tag message', default=defaults.get('tag_message', 'Bump version: {current_version} → {new_version}'))
 
     parser3.add_argument('--message', '-m', metavar='COMMIT_MSG',
                          help='Commit message',
-                         default=defaults.get('message', default_message))
+                         default=defaults.get('message', 'Bump version: {current_version} → {new_version}'))
 
     file_names = []
     if 'files' in defaults:

--- a/bumpversion/__init__.py
+++ b/bumpversion/__init__.py
@@ -12,23 +12,31 @@ try:
 except:
     from io import StringIO
 
-
 import argparse
+import codecs
+import io
 import os
+import platform
 import re
 import sre_constants
 import subprocess
+import sys
 import warnings
-import io
 from string import Formatter
 from datetime import datetime
 from difflib import unified_diff
 from tempfile import NamedTemporaryFile
 
-import sys
-import codecs
-
 from bumpversion.version_part import VersionPart, NumericVersionPartConfiguration, ConfiguredVersionPartConfiguration
+
+
+if platform.system() == 'Windows' and sys.version_info[0] == 2:
+    def _command_args(args):
+        return [a.encode("utf-8") for a in args]
+else:
+    def _command_args(args):
+        return args
+
 
 if sys.version_info[0] == 2:
     sys.stdout = codecs.getwriter('utf-8')(sys.stdout)
@@ -63,6 +71,7 @@ time_context = {
     'now': datetime.now(),
     'utcnow': datetime.utcnow(),
 }
+
 
 class BaseVCS(object):
 
@@ -153,7 +162,7 @@ class Git(BaseVCS):
 
     @classmethod
     def add_path(cls, path):
-        subprocess.check_output(["git", "add", "--update", path])
+        subprocess.check_output(_command_args(["git", "add", "--update", path]))
 
     @classmethod
     def tag(cls, sign, name, message):
@@ -162,7 +171,7 @@ class Git(BaseVCS):
             command += ['-s']
         if message:
             command += ['--message', message]
-        subprocess.check_output(command)
+        subprocess.check_output(_command_args(command))
 
 
 class Mercurial(BaseVCS):
@@ -201,7 +210,7 @@ class Mercurial(BaseVCS):
             )
         if message:
             command += ['--message', message]
-        subprocess.check_output(command)
+        subprocess.check_output(_command_args(command))
 
 VCS = [Git, Mercurial]
 

--- a/bumpversion/__init__.py
+++ b/bumpversion/__init__.py
@@ -811,11 +811,11 @@ def main(original_args=None):
                          default=defaults.get('tag_name', 'v{new_version}'))
 
     parser3.add_argument('--tag-message', metavar='TAG_MESSAGE', dest='tag_message',
-                         help='Tag message', default=defaults.get('tag_message', 'Bump version: {current_version} → {new_version}'))
+                         help='Tag message', default=defaults.get('tag_message', 'Bump version: {current_version} to {new_version}'))
 
     parser3.add_argument('--message', '-m', metavar='COMMIT_MSG',
                          help='Commit message',
-                         default=defaults.get('message', 'Bump version: {current_version} → {new_version}'))
+                         default=defaults.get('message', 'Bump version: {current_version} to {new_version}'))
 
     file_names = []
     if 'files' in defaults:

--- a/bumpversion/__init__.py
+++ b/bumpversion/__init__.py
@@ -72,7 +72,7 @@ class BaseVCS(object):
         f.write(message.encode('utf-8'))
         f.close()
         env = os.environ.copy()
-        env['HGENCODING'] = 'utf-8'
+        env[str('HGENCODING')] = str('utf-8')
         try:
             subprocess.check_output(cls._COMMIT_COMMAND + [f.name], env=env)
         except subprocess.CalledProcessError as exc:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -69,7 +69,6 @@ def _mock_calls_to_string(called_mock):
     ) for name, args, kwargs in called_mock.mock_calls]
 
 
-
 EXPECTED_OPTIONS = """
 [-h]
 [--config-file FILE]
@@ -133,10 +132,10 @@ optional arguments:
                         v{new_version})
   --tag-message TAG_MESSAGE
                         Tag message (default: Bump version: {current_version}
-                        → {new_version})
+                        to {new_version})
   --message COMMIT_MSG, -m COMMIT_MSG
                         Commit message (default: Bump version:
-                        {current_version} → {new_version})
+                        {current_version} to {new_version})
 """ % DESCRIPTION).lstrip()
 
 
@@ -435,7 +434,7 @@ def test_commit_and_tag(tmpdir, vcs):
 
     assert '-47.1.1' in log
     assert '+47.1.2' in log
-    assert 'Bump version: 47.1.1 → 47.1.2' in log
+    assert 'Bump version: 47.1.1 to 47.1.2' in log
 
     tag_out = check_output([vcs, {"git": "tag", "hg": "tags"}[vcs]])
 
@@ -471,7 +470,7 @@ def test_commit_and_tag_with_configfile(tmpdir, vcs):
 
     assert '-48.1.1' in log
     assert '+48.1.2' in log
-    assert 'Bump version: 48.1.1 → 48.1.2' in log
+    assert 'Bump version: 48.1.1 to 48.1.2' in log
 
     tag_out = check_output([vcs, {"git": "tag", "hg": "tags"}[vcs]])
 
@@ -512,7 +511,7 @@ def test_commit_and_not_tag_with_configfile(tmpdir, vcs, config):
 
     assert '-48.1.1' in log
     assert '+48.1.2' in log
-    assert 'Bump version: 48.1.1 → 48.1.2' in log
+    assert 'Bump version: 48.1.1 to 48.1.2' in log
 
     tag_out = check_output([vcs, {"git": "tag", "hg": "tags"}[vcs]])
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -31,7 +31,7 @@ def _get_subprocess_env():
 
 SUBPROCESS_ENV = _get_subprocess_env()
 
-call = partial(subprocess.call, env=SUBPROCESS_ENV)
+call = partial(subprocess.call, env=SUBPROCESS_ENV, shell=True)
 check_call = partial(subprocess.check_call, env=SUBPROCESS_ENV)
 check_output = partial(subprocess.check_output,  env=SUBPROCESS_ENV)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -153,10 +153,15 @@ def test_usage_string(tmpdir, capsys):
 
     assert EXPECTED_USAGE in out
 
-@pytest.mark.xfail(platform.system() == "Windows" and six.PY3,
-                   reason="Windows encoding problems")
+
 def test_usage_string_fork(tmpdir, capsys):
     tmpdir.chdir()
+    
+    if platform.system() == "Windows" and six.PY3:
+        # There are encoding problems on Windows with the encoding of →
+        tmpdir.join(".bumpversion.cfg").write("""[bumpversion]
+    message: Bump version: {current_version} to {new_version}
+    tag_message: 'Bump version: {current_version} → {new_version}""")
 
     try:
         out = check_output('bumpversion --help', shell=True, stderr=subprocess.STDOUT)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -157,6 +157,12 @@ def test_usage_string(tmpdir, capsys):
 def test_usage_string_fork(tmpdir, capsys):
     tmpdir.chdir()
 
+    if platform.system() == "Windows" and six.PY3:
+        # There are encoding problems on Windows with the encoding of →
+        tmpdir.join(".bumpversion.cfg").write("""[bumpversion]
+    message: Bump version: {current_version} to {new_version}
+    tag_message: 'Bump version: {current_version} to {new_version}""")
+
     try:
         out = check_output('bumpversion --help', shell=True, stderr=subprocess.STDOUT)
     except subprocess.CalledProcessError as e:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,21 +2,20 @@
 
 from __future__ import unicode_literals, print_function
 
-import os
-import pytest
-import sys
-import logging
-import mock
-
 import argparse
+import bumpversion
+import mock
+import os
+import platform
+import pytest
+
+import six
 import subprocess
-from os import curdir, makedirs, chdir, environ
-from os.path import join, curdir, dirname
+from os import environ
 from shlex import split as shlex_split
 from textwrap import dedent
 from functools import partial
 
-import bumpversion
 
 from bumpversion import main, DESCRIPTION, WorkingDirectoryIsDirtyException, \
     split_args_in_optional_and_positional
@@ -154,7 +153,8 @@ def test_usage_string(tmpdir, capsys):
 
     assert EXPECTED_USAGE in out
 
-
+@pytest.mark.xfail(platform.system() == "Windows" and six.PY3,
+                   reason="Windows encoding problems")
 def test_usage_string_fork(tmpdir, capsys):
     tmpdir.chdir()
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1185,8 +1185,8 @@ def test_subjunctive_dry_run_logging(tmpdir, vcs):
         info|Would prepare Git commit|
         info|Would add changes in file 'dont_touch_me.txt' to Git|
         info|Would add changes in file '.bumpversion.cfg' to Git|
-        info|Would commit to Git with message 'Bump version: 0.8 to 0.8.1'|
-        info|Would tag 'v0.8.1' with message 'Bump version: 0.8 to 0.8.1' in Git and not signing|
+        info|Would commit to Git with message 'Bump version: 0.8 \u2192 0.8.1'|
+        info|Would tag 'v0.8.1' with message 'Bump version: 0.8 \u2192 0.8.1' in Git and not signing|
         """).strip()
 
     if vcs == "hg":
@@ -1251,8 +1251,8 @@ def test_log_commitmessage_if_no_commit_tag_but_usable_vcs(tmpdir, vcs):
         info|Would prepare Git commit|
         info|Would add changes in file 'please_touch_me.txt' to Git|
         info|Would add changes in file '.bumpversion.cfg' to Git|
-        info|Would commit to Git with message 'Bump version: 0.3.3 to 0.3.4'|
-        info|Would tag 'v0.3.4' with message 'Bump version: 0.3.3 to 0.3.4' in Git and not signing|
+        info|Would commit to Git with message 'Bump version: 0.3.3 \u2192 0.3.4'|
+        info|Would tag 'v0.3.4' with message 'Bump version: 0.3.3 \u2192 0.3.4' in Git and not signing|
         """).strip()
 
     if vcs == "hg":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -907,17 +907,21 @@ def test_non_vcs_operations_if_vcs_is_not_installed(tmpdir, vcs, monkeypatch):
     assert '32.0.0' == tmpdir.join("VERSION").read()
 
 def test_serialize_newline(tmpdir):
-    tmpdir.join("filenewline").write("MAJOR=31\nMINOR=0\nPATCH=3\n")
+    def replace_newline(data):
+        return data.replace('\n', os.linesep).replace(repr('\n')[1:-1], repr(os.linesep)[1:-1])
+
+    tmpdir.join("filenewline").write(replace_newline("MAJOR=31\nMINOR=0\nPATCH=3\n"))
     tmpdir.chdir()
     main([
-        '--current-version', 'MAJOR=31\nMINOR=0\nPATCH=3\n',
-        '--parse', 'MAJOR=(?P<major>\d+)\\nMINOR=(?P<minor>\d+)\\nPATCH=(?P<patch>\d+)\\n',
-        '--serialize', 'MAJOR={major}\nMINOR={minor}\nPATCH={patch}\n',
+        '--current-version', replace_newline('MAJOR=31\nMINOR=0\nPATCH=3\n'),
+        '--parse',
+        replace_newline('MAJOR=(?P<major>\d+)\\nMINOR=(?P<minor>\d+)\\nPATCH=(?P<patch>\d+)\\n'),
+        '--serialize', replace_newline('MAJOR={major}\nMINOR={minor}\nPATCH={patch}\n'),
         '--verbose',
         'major',
         'filenewline'
         ])
-    assert 'MAJOR=32\nMINOR=0\nPATCH=0\n' == tmpdir.join("filenewline").read()
+    assert replace_newline('MAJOR=32\nMINOR=0\nPATCH=0\n') == tmpdir.join("filenewline").read()
 
 def test_multiple_serialize_threepart(tmpdir):
     tmpdir.join("fileA").write("Version: 0.9")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,20 +2,24 @@
 
 from __future__ import unicode_literals, print_function
 
-import argparse
-import bumpversion
-import mock
 import os
 import pytest
-import six
+import sys
+import logging
+import mock
+
+import argparse
 import subprocess
+from os import curdir, makedirs, chdir, environ
+from os.path import join, curdir, dirname
+from shlex import split as shlex_split
+from textwrap import dedent
+from functools import partial
+
+import bumpversion
 
 from bumpversion import main, DESCRIPTION, WorkingDirectoryIsDirtyException, \
     split_args_in_optional_and_positional
-from functools import partial
-from os import environ
-from shlex import split as shlex_split
-from textwrap import dedent
 
 
 def _get_subprocess_env():
@@ -153,17 +157,16 @@ def test_usage_string(tmpdir, capsys):
 
 def test_usage_string_fork(tmpdir, capsys):
     tmpdir.chdir()
-    kwargs = {} if six.PY2 else {"encoding": "utf-8"}
 
     try:
-        out = check_output('bumpversion --help', shell=True, stderr=subprocess.STDOUT, **kwargs)
+        out = check_output('bumpversion --help', shell=True, stderr=subprocess.STDOUT)
     except subprocess.CalledProcessError as e:
         out = e.output
 
-    if not 'usage: bumpversion [-h]' in out:
+    if not b'usage: bumpversion [-h]' in out:
         print(out)
 
-    assert 'usage: bumpversion [-h]' in out
+    assert b'usage: bumpversion [-h]' in out
 
 
 @pytest.mark.parametrize(("vcs"), [xfail_if_no_git("git"), xfail_if_no_hg("hg")])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,24 +2,20 @@
 
 from __future__ import unicode_literals, print_function
 
+import argparse
+import bumpversion
+import mock
 import os
 import pytest
-import sys
-import logging
-import mock
-
-import argparse
+import six
 import subprocess
-from os import curdir, makedirs, chdir, environ
-from os.path import join, curdir, dirname
-from shlex import split as shlex_split
-from textwrap import dedent
-from functools import partial
-
-import bumpversion
 
 from bumpversion import main, DESCRIPTION, WorkingDirectoryIsDirtyException, \
     split_args_in_optional_and_positional
+from functools import partial
+from os import environ
+from shlex import split as shlex_split
+from textwrap import dedent
 
 
 def _get_subprocess_env():
@@ -157,16 +153,17 @@ def test_usage_string(tmpdir, capsys):
 
 def test_usage_string_fork(tmpdir, capsys):
     tmpdir.chdir()
+    kwargs = {} if six.PY2 else {"encoding": "utf-8"}
 
     try:
-        out = check_output('bumpversion --help', shell=True, stderr=subprocess.STDOUT)
+        out = check_output('bumpversion --help', shell=True, stderr=subprocess.STDOUT, **kwargs)
     except subprocess.CalledProcessError as e:
         out = e.output
 
-    if not b'usage: bumpversion [-h]' in out:
+    if not 'usage: bumpversion [-h]' in out:
         print(out)
 
-    assert b'usage: bumpversion [-h]' in out
+    assert 'usage: bumpversion [-h]' in out
 
 
 @pytest.mark.parametrize(("vcs"), [xfail_if_no_git("git"), xfail_if_no_hg("hg")])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -156,12 +156,12 @@ def test_usage_string(tmpdir, capsys):
 
 def test_usage_string_fork(tmpdir, capsys):
     tmpdir.chdir()
-    
+
     if platform.system() == "Windows" and six.PY3:
         # There are encoding problems on Windows with the encoding of →
         tmpdir.join(".bumpversion.cfg").write("""[bumpversion]
     message: Bump version: {current_version} to {new_version}
-    tag_message: 'Bump version: {current_version} → {new_version}""")
+    tag_message: 'Bump version: {current_version} to {new_version}""")
 
     try:
         out = check_output('bumpversion --help', shell=True, stderr=subprocess.STDOUT)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1189,8 +1189,8 @@ def test_subjunctive_dry_run_logging(tmpdir, vcs):
         info|Would prepare Git commit|
         info|Would add changes in file 'dont_touch_me.txt' to Git|
         info|Would add changes in file '.bumpversion.cfg' to Git|
-        info|Would commit to Git with message 'Bump version: 0.8 \u2192 0.8.1'|
-        info|Would tag 'v0.8.1' with message 'Bump version: 0.8 \u2192 0.8.1' in Git and not signing|
+        info|Would commit to Git with message 'Bump version: 0.8 to 0.8.1'|
+        info|Would tag 'v0.8.1' with message 'Bump version: 0.8 to 0.8.1' in Git and not signing|
         """).strip()
 
     if vcs == "hg":
@@ -1255,8 +1255,8 @@ def test_log_commitmessage_if_no_commit_tag_but_usable_vcs(tmpdir, vcs):
         info|Would prepare Git commit|
         info|Would add changes in file 'please_touch_me.txt' to Git|
         info|Would add changes in file '.bumpversion.cfg' to Git|
-        info|Would commit to Git with message 'Bump version: 0.3.3 \u2192 0.3.4'|
-        info|Would tag 'v0.3.4' with message 'Bump version: 0.3.3 \u2192 0.3.4' in Git and not signing|
+        info|Would commit to Git with message 'Bump version: 0.3.3 to 0.3.4'|
+        info|Would tag 'v0.3.4' with message 'Bump version: 0.3.3 to 0.3.4' in Git and not signing|
         """).strip()
 
     if vcs == "hg":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -154,19 +154,20 @@ def test_usage_string(tmpdir, capsys):
 
     assert EXPECTED_USAGE in out
 
+
 def test_usage_string_fork(tmpdir, capsys):
     tmpdir.chdir()
 
     try:
-        out = check_output('bumpversion --help', shell=True, stderr=subprocess.STDOUT).decode('utf-8')
+        out = check_output('bumpversion --help', shell=True, stderr=subprocess.STDOUT)
     except subprocess.CalledProcessError as e:
-        out = e.output.decode('utf-8')
+        out = e.output
 
-    if not 'usage: bumpversion [-h]' in out:
+    if not b'usage: bumpversion [-h]' in out:
         print(out)
 
-    assert 'usage: bumpversion [-h]' in out
-    assert False
+    assert b'usage: bumpversion [-h]' in out
+
 
 @pytest.mark.parametrize(("vcs"), [xfail_if_no_git("git"), xfail_if_no_hg("hg")])
 def test_regression_help_in_workdir(tmpdir, capsys, vcs):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -157,12 +157,6 @@ def test_usage_string(tmpdir, capsys):
 def test_usage_string_fork(tmpdir, capsys):
     tmpdir.chdir()
 
-    if platform.system() == "Windows" and six.PY3:
-        # There are encoding problems on Windows with the encoding of →
-        tmpdir.join(".bumpversion.cfg").write("""[bumpversion]
-    message: Bump version: {current_version} to {new_version}
-    tag_message: 'Bump version: {current_version} to {new_version}""")
-
     try:
         out = check_output('bumpversion --help', shell=True, stderr=subprocess.STDOUT)
     except subprocess.CalledProcessError as e:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -69,6 +69,7 @@ def _mock_calls_to_string(called_mock):
     ) for name, args, kwargs in called_mock.mock_calls]
 
 
+
 EXPECTED_OPTIONS = """
 [-h]
 [--config-file FILE]
@@ -132,10 +133,10 @@ optional arguments:
                         v{new_version})
   --tag-message TAG_MESSAGE
                         Tag message (default: Bump version: {current_version}
-                        to {new_version})
+                        → {new_version})
   --message COMMIT_MSG, -m COMMIT_MSG
                         Commit message (default: Bump version:
-                        {current_version} to {new_version})
+                        {current_version} → {new_version})
 """ % DESCRIPTION).lstrip()
 
 
@@ -434,7 +435,7 @@ def test_commit_and_tag(tmpdir, vcs):
 
     assert '-47.1.1' in log
     assert '+47.1.2' in log
-    assert 'Bump version: 47.1.1 to 47.1.2' in log
+    assert 'Bump version: 47.1.1 → 47.1.2' in log
 
     tag_out = check_output([vcs, {"git": "tag", "hg": "tags"}[vcs]])
 
@@ -470,7 +471,7 @@ def test_commit_and_tag_with_configfile(tmpdir, vcs):
 
     assert '-48.1.1' in log
     assert '+48.1.2' in log
-    assert 'Bump version: 48.1.1 to 48.1.2' in log
+    assert 'Bump version: 48.1.1 → 48.1.2' in log
 
     tag_out = check_output([vcs, {"git": "tag", "hg": "tags"}[vcs]])
 
@@ -511,7 +512,7 @@ def test_commit_and_not_tag_with_configfile(tmpdir, vcs, config):
 
     assert '-48.1.1' in log
     assert '+48.1.2' in log
-    assert 'Bump version: 48.1.1 to 48.1.2' in log
+    assert 'Bump version: 48.1.1 → 48.1.2' in log
 
     tag_out = check_output([vcs, {"git": "tag", "hg": "tags"}[vcs]])
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -907,21 +907,17 @@ def test_non_vcs_operations_if_vcs_is_not_installed(tmpdir, vcs, monkeypatch):
     assert '32.0.0' == tmpdir.join("VERSION").read()
 
 def test_serialize_newline(tmpdir):
-    def replace_newline(data):
-        return data.replace('\n', os.linesep).replace(repr('\n')[1:-1], repr(os.linesep)[1:-1])
-
-    tmpdir.join("filenewline").write(replace_newline("MAJOR=31\nMINOR=0\nPATCH=3\n"))
+    tmpdir.join("filenewline").write("MAJOR=31\nMINOR=0\nPATCH=3\n")
     tmpdir.chdir()
     main([
-        '--current-version', replace_newline('MAJOR=31\nMINOR=0\nPATCH=3\n'),
-        '--parse',
-        replace_newline('MAJOR=(?P<major>\d+)\\nMINOR=(?P<minor>\d+)\\nPATCH=(?P<patch>\d+)\\n'),
-        '--serialize', replace_newline('MAJOR={major}\nMINOR={minor}\nPATCH={patch}\n'),
+        '--current-version', 'MAJOR=31\nMINOR=0\nPATCH=3\n',
+        '--parse', 'MAJOR=(?P<major>\d+)\\nMINOR=(?P<minor>\d+)\\nPATCH=(?P<patch>\d+)\\n',
+        '--serialize', 'MAJOR={major}\nMINOR={minor}\nPATCH={patch}\n',
         '--verbose',
         'major',
         'filenewline'
         ])
-    assert replace_newline('MAJOR=32\nMINOR=0\nPATCH=0\n') == tmpdir.join("filenewline").read()
+    assert 'MAJOR=32\nMINOR=0\nPATCH=0\n' == tmpdir.join("filenewline").read()
 
 def test_multiple_serialize_threepart(tmpdir):
     tmpdir.join("fileA").write("Version: 0.9")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -160,12 +160,13 @@ def test_usage_string_fork(tmpdir, capsys):
     try:
         out = check_output('bumpversion --help', shell=True, stderr=subprocess.STDOUT).decode('utf-8')
     except subprocess.CalledProcessError as e:
-        out = e.output
+        out = e.output.decode('utf-8')
 
     if not 'usage: bumpversion [-h]' in out:
         print(out)
 
     assert 'usage: bumpversion [-h]' in out
+    assert False
 
 @pytest.mark.parametrize(("vcs"), [xfail_if_no_git("git"), xfail_if_no_hg("hg")])
 def test_regression_help_in_workdir(tmpdir, capsys, vcs):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -21,10 +21,14 @@ import bumpversion
 from bumpversion import main, DESCRIPTION, WorkingDirectoryIsDirtyException, \
     split_args_in_optional_and_positional
 
+
 def _get_subprocess_env():
     env = os.environ.copy()
-    env['HGENCODING'] = 'utf-8'
+    # In python2 cast to str from unicode (note the future import).
+    # In python3 does nothing.
+    env[str('HGENCODING')] = str('utf-8')
     return env
+
 SUBPROCESS_ENV = _get_subprocess_env()
 
 call = partial(subprocess.call, env=SUBPROCESS_ENV)


### PR DESCRIPTION
This PR fixes issues on the Windows platform, particularly python2, revealed in the appveyor test failures.
In particular, encoding when making external calls with `subprocess` was usually incorrect.

Two specific changes on py2:
- use strings not unicode to add to the environment before making `subprocess` calls
- encode any non-ascii command line arguments (particularly `→`) in utf-8 before making the call.

A third change for both py2 and py3 is to change the file operations to text mode rather than binary mode, which simplifies handling of encoding.

In the tests, two further issues were addressed:
- incorrect handling when `hg` (or presumably `git`) is absent (this issue was not visible on appveyor, but locally to me)
- `test_usage_string_fork` changed to not explicit encode, and to use byte strings instead; xfailing in the most difficult case to fix: Windows on py3.

NB: I don't have a windows machine, so I am entirely reliant on appveyor for above analysis