### PR TITLE
Windows behavior fixed, with appveyor tests passing (B)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,6 +105,8 @@ venv.bak/
 .spyderproject
 .spyproject
 
+.idea
+
 # Rope project settings
 .ropeproject
 
@@ -129,3 +131,4 @@ Session.vim
 
 # Auto-generated tag files
 tags
+.pytest_cache

--- a/bumpversion/__init__.py
+++ b/bumpversion/__init__.py
@@ -15,6 +15,7 @@ except:
 
 import argparse
 import os
+import platform
 import re
 import sre_constants
 import subprocess
@@ -29,6 +30,15 @@ import sys
 import codecs
 
 from bumpversion.version_part import VersionPart, NumericVersionPartConfiguration, ConfiguredVersionPartConfiguration
+
+
+if platform.system() == 'Windows' and sys.version_info[0] == 2:
+    def _command_args(args):
+        return [a.encode("utf-8") for a in args]
+else:
+    def _command_args(args):
+        return args
+
 
 if sys.version_info[0] == 2:
     sys.stdout = codecs.getwriter('utf-8')(sys.stdout)
@@ -153,7 +163,7 @@ class Git(BaseVCS):
 
     @classmethod
     def add_path(cls, path):
-        subprocess.check_output(["git", "add", "--update", path])
+        subprocess.check_output(_command_args(["git", "add", "--update", path]))
 
     @classmethod
     def tag(cls, sign, name, message):
@@ -162,7 +172,7 @@ class Git(BaseVCS):
             command += ['-s']
         if message:
             command += ['--message', message]
-        subprocess.check_output(command)
+        subprocess.check_output(_command_args(command))
 
 
 class Mercurial(BaseVCS):
@@ -201,7 +211,7 @@ class Mercurial(BaseVCS):
             )
         if message:
             command += ['--message', message]
-        subprocess.check_output(command)
+        subprocess.check_output(_command_args(command))
 
 VCS = [Git, Mercurial]
 

--- a/bumpversion/__init__.py
+++ b/bumpversion/__init__.py
@@ -12,22 +12,20 @@ try:
 except:
     from io import StringIO
 
-
 import argparse
+import codecs
+import io
 import os
 import platform
 import re
 import sre_constants
 import subprocess
+import sys
 import warnings
-import io
 from string import Formatter
 from datetime import datetime
 from difflib import unified_diff
 from tempfile import NamedTemporaryFile
-
-import sys
-import codecs
 
 from bumpversion.version_part import VersionPart, NumericVersionPartConfiguration, ConfiguredVersionPartConfiguration
 
@@ -73,6 +71,7 @@ time_context = {
     'now': datetime.now(),
     'utcnow': datetime.utcnow(),
 }
+
 
 class BaseVCS(object):
 
@@ -243,12 +242,12 @@ class ConfiguredFile(object):
         assert False, msg
 
     def contains(self, search):
-        with io.open(self.path, 'rb') as f:
+        with io.open(self.path, 'rt', encoding='utf-8') as f:
             search_lines = search.splitlines()
             lookbehind = []
 
             for lineno, line in enumerate(f.readlines()):
-                lookbehind.append(line.decode('utf-8').rstrip("\n"))
+                lookbehind.append(line.rstrip("\n"))
 
                 if len(lookbehind) > len(search_lines):
                     lookbehind = lookbehind[1:]
@@ -257,14 +256,14 @@ class ConfiguredFile(object):
                    search_lines[-1] in lookbehind[-1] and
                    search_lines[1:-1] == lookbehind[1:-1]):
                     logger.info("Found '{}' in {} at line {}: {}".format(
-                        search, self.path, lineno - (len(lookbehind) - 1), line.decode('utf-8').rstrip()))
+                        search, self.path, lineno - (len(lookbehind) - 1), line.rstrip()))
                     return True
         return False
 
     def replace(self, current_version, new_version, context, dry_run):
 
-        with io.open(self.path, 'rb') as f:
-            file_content_before = f.read().decode('utf-8')
+        with io.open(self.path, 'rt', encoding='utf-8') as f:
+            file_content_before = f.read()
 
         context['current_version'] = self._versionconfig.serialize(current_version, context)
         context['new_version'] = self._versionconfig.serialize(new_version, context)
@@ -302,8 +301,8 @@ class ConfiguredFile(object):
             ))
 
         if not dry_run:
-            with io.open(self.path, 'wb') as f:
-                f.write(file_content_after.encode('utf-8'))
+            with io.open(self.path, 'wt', encoding='utf-8') as f:
+                f.write(file_content_after)
 
     def __str__(self):
         return self.path
@@ -902,8 +901,8 @@ def main(original_args=None):
         logger.info(new_config.getvalue())
 
         if write_to_config_file:
-            with io.open(config_file, 'wb') as f:
-                f.write(new_config.getvalue().encode('utf-8'))
+            with io.open(config_file, 'wt', encoding='utf-8') as f:
+                f.write(new_config.getvalue())
 
     except UnicodeEncodeError:
         warnings.warn(

--- a/bumpversion/__init__.py
+++ b/bumpversion/__init__.py
@@ -72,7 +72,7 @@ class BaseVCS(object):
         f.write(message.encode('utf-8'))
         f.close()
         env = os.environ.copy()
-        env['HGENCODING'] = 'utf-8'
+        env[str('HGENCODING')] = str('utf-8')
         try:
             subprocess.check_output(cls._COMMIT_COMMAND + [f.name], env=env)
         except subprocess.CalledProcessError as exc:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -31,7 +31,7 @@ def _get_subprocess_env():
 
 SUBPROCESS_ENV = _get_subprocess_env()
 
-call = partial(subprocess.call, env=SUBPROCESS_ENV)
+call = partial(subprocess.call, env=SUBPROCESS_ENV, shell=True)
 check_call = partial(subprocess.check_call, env=SUBPROCESS_ENV)
 check_output = partial(subprocess.check_output,  env=SUBPROCESS_ENV)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -21,10 +21,14 @@ import bumpversion
 from bumpversion import main, DESCRIPTION, WorkingDirectoryIsDirtyException, \
     split_args_in_optional_and_positional
 
+
 def _get_subprocess_env():
     env = os.environ.copy()
-    env['HGENCODING'] = 'utf-8'
+    # In python2 cast to str from unicode (note the future import).
+    # In python3 does nothing.
+    env[str('HGENCODING')] = str('utf-8')
     return env
+
 SUBPROCESS_ENV = _get_subprocess_env()
 
 call = partial(subprocess.call, env=SUBPROCESS_ENV)


### PR DESCRIPTION
This replaces my [previous PR](https://github.com/c4urself/bump2version/pull/33) on this topic, with cleaned up commit history, and no longer and extra xfail.

This PR fixes issues on the Windows platform, particularly python2, revealed in the appveyor test failures.
In particular, encoding when making external calls with subprocess was usually incorrect.

Two specific changes on py2:

use strings not unicode to add to the environment before making subprocess calls
encode any non-ascii command line arguments (particularly →) in utf-8 before making the call.
A third change for both py2 and py3 is to change the file operations to text mode rather than binary mode, which simplifies handling of encoding.

In the tests, two further issues were addressed:

incorrect handling when hg (or presumably git) is absent (this issue was not visible on appveyor, but locally to me)
test_usage_string_fork changed to not explicit encode, and to use byte strings instead; xfailing in the most difficult case to fix: Windows on py3.
NB: I don't have a windows machine, so I am entirely reliant on appveyor for above analysis.

Concerning `test_usage_string_fork`. This would fail in python3 on windows, except for the additional code for that case, which provides a `.bumpversion.cfg` file which replaces the unicode character `→` with the ascii string `to` in the tag message and the commit message. Without this, I think there is a genuine defect (although I don't have a Windows machine) in which the `-h` option attempts to print out this character as part of the help message and fails. Essentially `bumpversion` assumes unicode support, and the workaround at least is to change those two strings explicitly in the `.bumpversion.cfg` or on the command line.