### PR TITLE
Reverse StringIO import logic

### DIFF
--- a/bumpversion/__init__.py
+++ b/bumpversion/__init__.py
@@ -10,11 +10,11 @@ except ImportError:
     from ConfigParser import RawConfigParser, SafeConfigParser as ConfigParser, NoOptionError
 
 try:
-    # Python 2
-    from StringIO import StringIO
-except ImportError:
     # Python 3
     from io import StringIO
+except ImportError:
+    # Python 2
+    from StringIO import StringIO
 
 import argparse
 import codecs

--- a/bumpversion/__init__.py
+++ b/bumpversion/__init__.py
@@ -5,15 +5,10 @@ from __future__ import unicode_literals
 try:
     # Python 3 or pip-installed "configparser" on Python 2
     from configparser import RawConfigParser, ConfigParser, NoOptionError
+    from io import StringIO
 except ImportError:
     # On Py2, "SafeConfigParser" is the same as "ConfigParser" on Py3
     from ConfigParser import RawConfigParser, SafeConfigParser as ConfigParser, NoOptionError
-
-try:
-    # Python 3
-    from io import StringIO
-except ImportError:
-    # Python 2
     from StringIO import StringIO
 
 import argparse


### PR DESCRIPTION
Try the Python 3 import before falling back to Python 2 (as suggested in https://github.com/c4urself/bump2version/commit/e5688dc7d5aeaab1d35801506585e151c9cbf93a#comments)