### PR TITLE
Expose major/minor/patch and custom parts in all configurable strings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,9 @@ test:
 	docker-compose build test
 	docker-compose run test
 
+local_test:
+	PYTHONPATH=. py.test tests/
+
 lint:
 	pip install pylint
 	pylint bumpversion

--- a/README.md
+++ b/README.md
@@ -146,8 +146,10 @@ General configuration is grouped in a `[bumpversion]` section.
 
   This is templated using the [Python Format String Syntax](http://docs.python.org/2/library/string.html#format-string-syntax)
   Available in the template context are `current_version` and `new_version`
-  as well as all environment variables (prefixed with `$`). You can also use
-  the variables `now` or `utcnow` to get a current timestamp. Both accept
+  as well as `current_[part]` and `new_[part]` (e.g. '`current_major`'
+  or '`new_patch`').
+  In addtion, all environment variables are exposed, prefixed with `$`.  
+  You can also use the variables `now` or `utcnow` to get a current timestamp. Both accept
   datetime formatting (when used like as in `{now:%d.%m.%Y}`).
 
   Also available as a command line flag, `--tag-name` (e.g. `bump2version --message 'Jenkins Build
@@ -178,8 +180,10 @@ General configuration is grouped in a `[bumpversion]` section.
 
   This is templated using the [Python Format String Syntax](http://docs.python.org/2/library/string.html#format-string-syntax)
   Available in the template context are `current_version` and `new_version`
-  as well as all environment variables (prefixed with `$`). You can also use
-  the variables `now` or `utcnow` to get a current timestamp. Both accept
+  as well as `current_[part]` and `new_[part]` (e.g. '`current_major`'
+  or '`new_patch`').
+  In addition, all environment variables are exposed, prefixed with `$`.  
+  You can also use the variables `now` or `utcnow` to get a current timestamp. Both accept
   datetime formatting (when used like as in `{now:%d.%m.%Y}`).
 
   Also available as `--message` (e.g.: `bump2version --message

--- a/README.md
+++ b/README.md
@@ -152,8 +152,8 @@ General configuration is grouped in a `[bumpversion]` section.
   You can also use the variables `now` or `utcnow` to get a current timestamp. Both accept
   datetime formatting (when used like as in `{now:%d.%m.%Y}`).
 
-  Also available as a command line flag, `--tag-name` (e.g. `bump2version --message 'Jenkins Build
-  {$BUILD_NUMBER}: {new_version}' patch`).
+  Also available as command-line flag `tag_name`.  Example usage:  
+  `bump2version --tag_name 'release-{new_version}' patch`
 
 #### `commit = (True | False)`
   _**[optional]**_<br />

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ General configuration is grouped in a `[bumpversion]` section.
 
   The name of the tag that will be created. Only valid when using `--tag` / `tag = True`.
 
-  This is templated using the [Python Format String Syntax](http://docs.python.org/2/library/string.html#format-string-syntax)
+  This is templated using the [Python Format String Syntax](http://docs.python.org/2/library/string.html#format-string-syntax).  
   Available in the template context are `current_version` and `new_version`
   as well as `current_[part]` and `new_[part]` (e.g. '`current_major`'
   or '`new_patch`').
@@ -178,16 +178,16 @@ General configuration is grouped in a `[bumpversion]` section.
 
   The commit message to use when creating a commit. Only valid when using `--commit` / `commit = True`.
 
-  This is templated using the [Python Format String Syntax](http://docs.python.org/2/library/string.html#format-string-syntax)
+  This is templated using the [Python Format String Syntax](http://docs.python.org/2/library/string.html#format-string-syntax).  
   Available in the template context are `current_version` and `new_version`
   as well as `current_[part]` and `new_[part]` (e.g. '`current_major`'
   or '`new_patch`').
   In addition, all environment variables are exposed, prefixed with `$`.  
   You can also use the variables `now` or `utcnow` to get a current timestamp. Both accept
   datetime formatting (when used like as in `{now:%d.%m.%Y}`).
-
-  Also available as `--message` (e.g.: `bump2version --message
-  '[{now:%Y-%m-%d}] Jenkins Build {$BUILD_NUMBER}: {new_version}' patch`)
+  
+  Also available as command-line flag `--message`.  Example usage:  
+  `bump2version --message '[{now:%Y-%m-%d}] Jenkins Build {$BUILD_NUMBER}: {new_version}' patch`)
 
 
 ### Configuration file -- Part specific configuration
@@ -281,7 +281,7 @@ This configuration is in the section: `[bumpversion:file:…]`
   Available in the template context are parsed values of the named groups
   specified in `parse =` as well as all environment variables (prefixed with
   `$`).
-
+  
   Can be specified multiple times, bumpversion will try the serialization
   formats beginning with the first and choose the last one where all values can
   be represented like this::
@@ -290,8 +290,8 @@ This configuration is in the section: `[bumpversion:file:…]`
       {major}.{minor}
       {major}
 
-  Given the example above, the new version *1.9* it will be serialized as
-  `1.9`, but the version *2.0* will be serialized as `2`.
+  Given the example above, the new version `1.9` will be serialized as
+  `1.9`, but the version `2.0` will be serialized as `2`.
 
   Also available as `--serialize`. Multiple values on the command line are
   given like `--serialize {major}.{minor} --serialize {major}`
@@ -301,7 +301,7 @@ This configuration is in the section: `[bumpversion:file:…]`
 
   Template string how to search for the string to be replaced in the file.
   Useful if the remotest possibility exists that the current version number
-  might be multiple times in the file and you mean to only bump one of the
+  might be present multiple times in the file and you mean to only bump one of the
   occurences. Can be multiple lines, templated using [Python Format String Syntax](http://docs.python.org/2/library/string.html#format-string-syntax)
 
 #### `replace =`

--- a/bumpversion/cli.py
+++ b/bumpversion/cli.py
@@ -628,7 +628,7 @@ def _update_config_file(
         )
 
 
-def _commit_to_vcs(files, context, config_file, config_file_exists, vcs, args):
+def _commit_to_vcs(files, context, config_file, config_file_exists, vcs, args, current_version, new_version):
     commit_files = [f.path for f in files]
     if config_file_exists:
         commit_files.append(config_file)
@@ -652,9 +652,17 @@ def _commit_to_vcs(files, context, config_file, config_file_exists, vcs, args):
         if do_commit:
             vcs.add_path(path)
 
-    context["current_version"] = args.current_version
-    context["new_version"] = args.new_version
+    context = {
+        "current_version": current_version,
+        "new_version": new_version,
+    }
+    context.update(time_context)
+    context.update(prefixed_environ())
+    context.update({'current_' + part: current_version[part].value for part in current_version})
+    context.update({'new_' + part: new_version[part].value for part in new_version})
+
     commit_message = args.message.format(**context)
+
     logger.info(
         "%s to %s with message '%s'",
         "Would commit" if not do_commit else "Committing",

--- a/bumpversion/cli.py
+++ b/bumpversion/cli.py
@@ -115,7 +115,7 @@ def main(original_args=None):
 
     # commit and tag
     if vcs:
-        context = _commit_to_vcs(files, context, config_file, config_file_exists, vcs, args)
+        context = _commit_to_vcs(files, context, config_file, config_file_exists, vcs, args, current_version, new_version)
         _tag_in_vcs(vcs, context, args)
 
 
@@ -653,8 +653,8 @@ def _commit_to_vcs(files, context, config_file, config_file_exists, vcs, args, c
             vcs.add_path(path)
 
     context = {
-        "current_version": current_version,
-        "new_version": new_version,
+        "current_version": args.current_version,
+        "new_version": args.new_version,
     }
     context.update(time_context)
     context.update(prefixed_environ())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -795,7 +795,7 @@ def test_all_parts_in_message_and_serialize_and_tag_name_from_config_file(tmpdir
     check_call([vcs, "add", "VERSION"])
     check_call([vcs, "commit", "-m", "initial commit"])
 
-    tmpdir.join(".bumpversion.cfg").write("""[bumpversion]
+    tmpdir.join(".bumpversion.cfg").write(r"""[bumpversion]
 current_version: 400.1.2.101
 new_version: 401.2.3.102
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+).(?P<custom>\d+)
@@ -827,7 +827,7 @@ def test_all_parts_in_replace_from_config_file(tmpdir, capsys, vcs):
     check_call([vcs, "add", "VERSION"])
     check_call([vcs, "commit", "-m", "initial commit"])
 
-    tmpdir.join(".bumpversion.cfg").write("""[bumpversion]
+    tmpdir.join(".bumpversion.cfg").write(r"""[bumpversion]
 current_version: 400.1.2.101
 new_version: 401.2.3.102
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+).(?P<custom>\d+)


### PR DESCRIPTION
Closes #35 

Currently, only `serialize` has access to the `part` identifiers such
as `{major}`, `{minor}` and `{patch}`.

This change exposes them also to other configurable strings, providing
more flexibility in formatting:

```
message
tag_name
tag_message
replace
```

To be intuitive relative to the existing `current_version`
and `new_version` identifiers, these are named `current_[part]`
and `new_[part]`.

Additionally, to be intuitive relative to the `[part]` identifiers
available in `serialize`, the `new_[part]` identifiers are also
exposed as `[part]` without the `new_` prefix.