### PR TITLE
Allow arbitrary arguments to commit command

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,21 @@ General configuration is grouped in a `[bumpversion]` section.
   Also available as command-line flag `--message`.  Example usage:  
   `bump2version --message '[{now:%Y-%m-%d}] Jenkins Build {$BUILD_NUMBER}: {new_version}' patch`)
 
+#### `commit_args =`
+  _**[optional**_<br />
+  **default:** empty
+
+  Extra arguments to pass to commit command. Only valid when using `--commit` /
+  `commit = True`.
+
+  This is for example useful to add `-s` to generate `Signed-off-by:` line in
+  the commit message.
+
+  Multiple arguments can be specified on separate lines.
+
+  Also available as command-line flag `--commit-args`, in which case only one
+  argument can be specified.
+
 
 ### Configuration file -- Part specific configuration
 

--- a/bumpversion/cli.py
+++ b/bumpversion/cli.py
@@ -534,6 +534,12 @@ def _parse_arguments_phase_3(remaining_argv, positionals, defaults, parser2):
             "message", "Bump version: {current_version} → {new_version}"
         ),
     )
+    parser3.add_argument(
+        "--commit-args",
+        metavar="COMMIT_ARGS",
+        help="Extra arguments to commit command",
+        default=defaults.get("commit_args", ""),
+    )
     file_names = []
     if "files" in defaults:
         assert defaults["files"] is not None
@@ -670,7 +676,11 @@ def _commit_to_vcs(files, context, config_file, config_file_exists, vcs, args, c
         commit_message,
     )
     if do_commit:
-        vcs.commit(message=commit_message, context=context)
+        vcs.commit(
+            message=commit_message,
+            context=context,
+            extra_args=[arg.strip() for arg in args.commit_args.splitlines()],
+        )
     return context
 
 

--- a/bumpversion/vcs.py
+++ b/bumpversion/vcs.py
@@ -24,7 +24,8 @@ class BaseVCS(object):
     _COMMIT_COMMAND = None
 
     @classmethod
-    def commit(cls, message, context):
+    def commit(cls, message, context, extra_args=None):
+        extra_args = extra_args or []
         with NamedTemporaryFile("wb", delete=False) as f:
             f.write(message.encode("utf-8"))
         env = os.environ.copy()
@@ -32,7 +33,9 @@ class BaseVCS(object):
         for key in ("current_version", "new_version"):
             env[str("BUMPVERSION_" + key.upper())] = str(context[key])
         try:
-            subprocess.check_output(cls._COMMIT_COMMAND + [f.name], env=env)
+            subprocess.check_output(
+                cls._COMMIT_COMMAND + [f.name] + extra_args, env=env
+            )
         except subprocess.CalledProcessError as exc:
             err_msg = "Failed to run {}: return code {}, output: {}".format(
                 exc.cmd, exc.returncode, exc.output


### PR DESCRIPTION
Basically just take these and tack them on the end of commit command. One use case may be to generate a Signed-off-by line.

I couldn't get the test suite to run so far, so maybe this will break it. But it works when testing manually.