### PR TITLE
Make 'part' optional (but not forbidden) when new_version is specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,11 @@ You can download and install the latest version of this software from the Python
 There are two modes of operation: On the command line for single-file operation
 and using a configuration file (`bumpversion.cfg`) for more complex multi-file operations.
 
-    bump2version [options] part [file]
+    bump2version [options] [part] [file]
 
 #### `part`
-  _**required**_<br />
+  _**[optional]**_<br />
+  **default**: none
 
   The part of the version to increase, e.g. `minor`.
 
@@ -110,9 +111,11 @@ General configuration is grouped in a `[bumpversion]` section.
 
   The version of the software package after the increment. If not given will be
   automatically determined.
+  
+  When `new_version` is defined, it's not necessary to supply `part`.
 
   Also available as `--new-version` (e.g. `to go from 0.5.1 directly to
-  0.6.1`: `bump2version --current-version 0.5.1 --new-version 0.6.1 patch
+  0.6.1`: `bump2version --current-version 0.5.1 --new-version 0.6.1
   setup.py`).
 
 #### `tag = (True | False)`

--- a/bumpversion/cli.py
+++ b/bumpversion/cli.py
@@ -509,6 +509,11 @@ def main(original_args=None):
     if not part_required and positionals and not os.path.exists(positionals[0]):
         # the first positional argument is not a valid path
         # treat it as a part for backwards compatibility reasons
+        warnings.warn(
+            "You have supplied an argument that's not a file while a part is not required. " +
+            "This will be deprecated.  Argument: '{0}'.".format(positionals[0]),
+            category=DeprecationWarning,
+        )
         part_required = True
 
     if part_required:

--- a/bumpversion/cli.py
+++ b/bumpversion/cli.py
@@ -503,7 +503,18 @@ def main(original_args=None):
         assert defaults["files"] is not None
         file_names = defaults["files"].split(" ")
 
-    parser3.add_argument("part", help="Part of the version to be bumped.")
+    # regarding positional arguments, accept [part] and file names
+    # but take into account that both are optional
+    part_required = '--new-version' not in remaining_argv and not defaults.get('new_version')
+    if not part_required and positionals and not os.path.exists(positionals[0]):
+        # the first positional argument is not a valid path
+        # treat it as a part for backwards compatibility reasons
+        part_required = True
+
+    if part_required:
+        parser3.add_argument('part', nargs=1, default=None,
+                             help='Part of the version to be bumped.')
+
     parser3.add_argument(
         "files", metavar="file", nargs="*", help="Files to change", default=file_names
     )
@@ -518,7 +529,7 @@ def main(original_args=None):
 
     logger.info("New version will be '{}'".format(args.new_version))
 
-    file_names = file_names or positionals[1:]
+    file_names = file_names or positionals[1 if part_required else 0:]
 
     for file_name in file_names:
         files.append(ConfiguredFile(file_name, vc))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -289,7 +289,7 @@ new_version: 0.9.35
 [bumpversion:file:file1]""")
 
     tmpdir.chdir()
-    main(shlex_split("patch --config-file my_bump_config.cfg"))
+    main(shlex_split("--config-file my_bump_config.cfg"))
 
     assert "0.9.35" == tmpdir.join("file1").read()
 
@@ -302,7 +302,7 @@ new_version: 0.10.3
 [bumpversion:file:file2]""")
 
     tmpdir.chdir()
-    main(['patch'])
+    main([])
 
     assert "0.10.3" == tmpdir.join("file2").read()
 
@@ -319,7 +319,7 @@ new_version: 0.10.4
 [bumpversion:file:file2]""")
 
     tmpdir.chdir()
-    main(['patch'])
+    main([])
 
     assert "0.10.4" == tmpdir.join("file2").read()
 
@@ -332,7 +332,7 @@ new_version: 0.0.14
 [bumpversion:file:file3]""")
 
     tmpdir.chdir()
-    main(['patch', '--verbose'])
+    main(['--verbose'])
 
     assert """[bumpversion]
 current_version = 0.0.14
@@ -436,7 +436,7 @@ def test_dirty_work_dir(tmpdir, vcs):
     with pytest.raises(WorkingDirectoryIsDirtyException):
         with mock.patch("bumpversion.cli.logger") as parser_logger:
             with mock.patch("bumpversion.vcs.logger") as vcs_logger:
-                main(['patch', '--current-version', '1', '--new-version', '2', 'file7'])
+                main(['--current-version', '1', '--new-version', '2', 'dirty'])
 
     actual_log = "\n".join(
         _mock_calls_to_string(parser_logger) +
@@ -789,7 +789,7 @@ tag: True
 message: {current_version} was old, {new_version} is new
 tag_name: from-{current_version}-to-{new_version}""")
 
-    main(['major', 'VERSION'])
+    main(['VERSION'])
 
     log = check_output([vcs, "log", "-p"])
 
@@ -1073,7 +1073,7 @@ def test_log_parse_doesnt_parse_current_version(tmpdir):
     tmpdir.chdir()
 
     with LogCapture() as log_capture:
-        main(['--verbose', '--parse', 'xxx', '--current-version', '12', '--new-version', '13', 'patch'])
+        main(['--verbose', '--parse', 'xxx', '--current-version', '12', '--new-version', '13'])
 
     log_capture.check_present(
         ('bumpversion.cli', 'INFO', "Could not read config file at .bumpversion.cfg"),
@@ -1908,7 +1908,7 @@ def test_regression_new_version_cli_in_files(tmpdir, capsys):
         [bumpversion:file:myp___init__.py]
         """).strip())
 
-    main("patch --allow-dirty --verbose --new-version 0.9.3".split(" "))
+    main("--allow-dirty --verbose --new-version 0.9.3".split(" "))
 
     assert "__version__ = '0.9.3'" == tmpdir.join("myp___init__.py").read()
     assert "current_version = 0.9.3" in tmpdir.join(".bumpversion.cfg").read()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -254,6 +254,7 @@ def test_missing_explicit_config_file(tmpdir):
         main(['--config-file', 'missing.cfg'])
 
 
+@pytest.mark.filterwarnings("ignore:.*part is not required.*deprecated.*:DeprecationWarning")
 def test_simple_replacement(tmpdir, optional_part):
     tmpdir.join("VERSION").write("1.2.0")
     tmpdir.chdir()
@@ -261,6 +262,7 @@ def test_simple_replacement(tmpdir, optional_part):
     assert "1.2.1" == tmpdir.join("VERSION").read()
 
 
+@pytest.mark.filterwarnings("ignore:.*part is not required.*deprecated.*:DeprecationWarning")
 def test_simple_replacement_in_utf8_file(tmpdir, optional_part):
     tmpdir.join("VERSION").write("Kröt1.3.0".encode('utf-8'), 'wb')
     tmpdir.chdir()
@@ -268,6 +270,15 @@ def test_simple_replacement_in_utf8_file(tmpdir, optional_part):
     main(shlex_split(optional_part + "--verbose --current-version 1.3.0 --new-version 1.3.1 VERSION"))
     out = tmpdir.join("VERSION").read('rb')
     assert "'Kr\\xc3\\xb6t1.3.1'" in repr(out)
+
+
+def test_unnecessary_part_argument_shows_deprecationwarning(tmpdir):
+    tmpdir.join("VERSION").write("1.2.0")
+    tmpdir.chdir()
+    pytest.deprecated_call(
+        main,
+        shlex_split("bogus-part --current-version 1.2.0 --new-version 1.2.1 VERSION"),
+    )
 
 
 def test_config_file(tmpdir):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -716,10 +716,18 @@ def test_override_vcs_current_version(tmpdir, git):
     assert '7.0.1' == tmpdir.join("contains_actual_version").read()
 
 
-def test_non_existing_file(tmpdir):
+@pytest.mark.parametrize(
+    "non_existing_file",
+    ["with/slash", "with\\backslash", "with_dot.txt", "all/of\\it.txt"],
+)
+def test_non_existing_file(tmpdir, non_existing_file):
     tmpdir.chdir()
     with pytest.raises(IOError):
-        main(shlex_split("patch --current-version 1.2.0 --new-version 1.2.1 does_not_exist.txt"))
+        main(shlex_split(
+            '--current-version 1.2.0 --new-version 1.2.1 "{}"'.format(
+                non_existing_file
+            )
+        ))
 
 
 def test_non_existing_second_file(tmpdir):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -69,6 +69,16 @@ def configfile(request):
     return request.param
 
 
+@pytest.fixture(params=["patch ", "nonexistant ", None])
+def optional_part(request):
+    """Return a real part, a bogus one, an no part at all."""
+    part = request.param
+    if not part:
+        return ""
+    # add extra space to separate from other main() arguments
+    return part + " "
+
+
 try:
     RawConfigParser(empty_lines_in_values=False)
     using_old_configparser = False
@@ -244,18 +254,18 @@ def test_missing_explicit_config_file(tmpdir):
         main(['--config-file', 'missing.cfg'])
 
 
-def test_simple_replacement(tmpdir):
+def test_simple_replacement(tmpdir, optional_part):
     tmpdir.join("VERSION").write("1.2.0")
     tmpdir.chdir()
-    main(shlex_split("patch --current-version 1.2.0 --new-version 1.2.1 VERSION"))
+    main(shlex_split(optional_part + "--current-version 1.2.0 --new-version 1.2.1 VERSION"))
     assert "1.2.1" == tmpdir.join("VERSION").read()
 
 
-def test_simple_replacement_in_utf8_file(tmpdir):
+def test_simple_replacement_in_utf8_file(tmpdir, optional_part):
     tmpdir.join("VERSION").write("Kröt1.3.0".encode('utf-8'), 'wb')
     tmpdir.chdir()
     out = tmpdir.join("VERSION").read('rb')
-    main(shlex_split("patch --verbose --current-version 1.3.0 --new-version 1.3.1 VERSION"))
+    main(shlex_split(optional_part + "--verbose --current-version 1.3.0 --new-version 1.3.1 VERSION"))
     out = tmpdir.join("VERSION").read('rb')
     assert "'Kr\\xc3\\xb6t1.3.1'" in repr(out)
 


### PR DESCRIPTION
This is an alternative implementation to #31 which tries to be backwards compatible to existing uses
which supply a `part` argument just because it's required by the CLI.

Closes #22

I think this will only break if the part argument is actually present on disk as a file.  That should be low probability since most files in the root will start with a dot or have an extension.

It's up to the maintainers to choose if #31 is preferred (it's definitely cleaner and less ambiguous) or if it's worth retaining backwards compatibility.

~Future work would be to update the documentation, and to add a deprecation warning when a useless `part` is supplied.~ (done now)