### PR TITLE
Extract code from cli.main into shorter methods

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,6 +29,7 @@ init:
   - ps: "ls C:/Python*"
 
 install:
+  - "%PYTHON%/python.exe -m pip install --upgrade wheel pip setuptools virtualenv"
   - "%PYTHON%/python.exe -m pip install tox"
   - "%PYTHON%/python.exe -m pip install -e ."
 

--- a/bumpversion/cli.py
+++ b/bumpversion/cli.py
@@ -114,32 +114,7 @@ def main(original_args=None):
     _check_files_contain_version(context, current_version, files)
     _replace_version_in_files(args, context, current_version, files, new_version)
     _log_list(args, config)
-
-    config.set("bumpversion", "current_version", args.new_version)
-
-    new_config = StringIO()
-
-    try:
-        write_to_config_file = (not args.dry_run) and config_file_exists
-
-        logger.info(
-            "%s to config file %s:",
-            "Would write" if not write_to_config_file else "Writing",
-            config_file
-        )
-
-        config.write(new_config)
-        logger.info(new_config.getvalue())
-
-        if write_to_config_file:
-            with io.open(config_file, "wt", encoding="utf-8", newline=config_new_lines) as f:
-                f.write(new_config.getvalue())
-
-    except UnicodeEncodeError:
-        warnings.warn(
-            "Unable to write UTF-8 to config file, because of an old configparser version. "
-            "Update with `pip install --upgrade configparser`."
-        )
+    _update_config_file(args, config, config_file, config_file_exists)
 
     commit_files = [f.path for f in files]
     if config_file_exists:
@@ -679,3 +654,29 @@ def _log_list(args, config):
     for key, value in config.items("bumpversion"):
         logger_list.info("{}={}".format(key, value))
     config.remove_option("bumpversion", "new_version")
+
+
+def _update_config_file(args, config, config_file, config_file_exists):
+    config.set("bumpversion", "current_version", args.new_version)
+    new_config = StringIO()
+    try:
+        write_to_config_file = (not args.dry_run) and config_file_exists
+
+        logger.info(
+            "{} to config file {}:".format(
+                "Would write" if not write_to_config_file else "Writing", config_file
+            )
+        )
+
+        config.write(new_config)
+        logger.info(new_config.getvalue())
+
+        if write_to_config_file:
+            with io.open(config_file, "wt", encoding="utf-8") as f:
+                f.write(new_config.getvalue())
+
+    except UnicodeEncodeError:
+        warnings.warn(
+            "Unable to write UTF-8 to config file, because of an old configparser version. "
+            "Update with `pip install --upgrade configparser`."
+        )

--- a/bumpversion/cli.py
+++ b/bumpversion/cli.py
@@ -111,16 +111,7 @@ def main(original_args=None):
     new_version = _parse_new_version(args, new_version, vc)
     _determine_files(file_names, files, positionals, vc)
     vcs = _determine_vcs_dirty(defaults, vcs)
-
-    # make sure files exist and contain version string
-
-    logger.info(
-        "Asserting files %s contain the version string...",
-        ", ".join([str(f) for f in files])
-    )
-
-    for f in files:
-        f.should_contain_version(current_version, context)
+    _check_files_contain_version(context, current_version, files)
 
     # change version string in files
     for f in files:
@@ -674,3 +665,14 @@ def _determine_vcs_dirty(defaults, vcs):
         else:
             vcs = None
     return vcs
+
+
+def _check_files_contain_version(context, current_version, files):
+    # make sure files exist and contain version string
+    logger.info(
+        "Asserting files {} contain the version string:".format(
+            ", ".join([str(f) for f in files])
+        )
+    )
+    for f in files:
+        f.should_contain_version(current_version, context)

--- a/bumpversion/cli.py
+++ b/bumpversion/cli.py
@@ -105,7 +105,7 @@ def main(original_args=None):
         explicit_config = known_args.config_file
     config_file = _determine_config_file(explicit_config)
     config, config_file_exists = _load_configuration(config_file, explicit_config, files, defaults, part_configs)
-    known_args, parser2, remaining_argv = _parse_phase_2(args, defaults, known_args, root_parser)
+    known_args, parser2, remaining_argv = _parse_arguments_phase_2(args, known_args, defaults, root_parser)
     vc = _setup_versionconfig(known_args, part_configs)
     current_version = _parse_current_version(known_args.current_version, vc)
     context = _assemble_context(vcs_info)
@@ -326,7 +326,7 @@ def _load_configuration(config_file, explicit_config, files, defaults, part_conf
     return config, config_file_exists
 
 
-def _parse_phase_2(args, defaults, known_args, root_parser):
+def _parse_arguments_phase_2(args, known_args, defaults, root_parser):
     parser2 = argparse.ArgumentParser(
         prog="bumpversion", add_help=False, parents=[root_parser]
     )

--- a/bumpversion/cli.py
+++ b/bumpversion/cli.py
@@ -588,8 +588,8 @@ def _replace_version_in_files(files, current_version, new_version, dry_run, cont
         f.replace(current_version, new_version, context, dry_run)
 
 
-def _log_list(args, config):
-    config.set("bumpversion", "new_version", args.new_version)
+def _log_list(config, new_version):
+    config.set("bumpversion", "new_version", new_version)
     for key, value in config.items("bumpversion"):
         logger_list.info("{}={}".format(key, value))
     config.remove_option("bumpversion", "new_version")

--- a/bumpversion/cli.py
+++ b/bumpversion/cli.py
@@ -107,7 +107,7 @@ def main(original_args=None):
     config, config_file_exists = _load_configuration(config_file, defaults, explicit_config, files, part_configs)
     known_args, parser2, remaining_argv = _parse_phase_2(args, defaults, known_args, root_parser)
     vc = _setup_versionconfig(known_args, part_configs)
-    current_version = _update_current_version(known_args, vc)
+    current_version = _parse_current_version(known_args.current_version, vc)
     context = _assemble_context(vcs_info)
     new_version = _assemble_new_version(context, current_version, defaults, known_args, new_version, positionals, vc)
     args, file_names = _parse_phase_3(args, defaults, parser2, positionals, remaining_argv)
@@ -388,11 +388,13 @@ def _setup_versionconfig(known_args, part_configs):
     return vc
 
 
-def _update_current_version(known_args, vc):
-    current_version = (
-        vc.parse(known_args.current_version) if known_args.current_version else None
+def _parse_current_version(current_version, vc):
+    if not current_version:
+        return (None)
+
+    return (
+        vc.parse(current_version)
     )
-    return current_version
 
 
 def _assemble_context(vcs_info):

--- a/bumpversion/cli.py
+++ b/bumpversion/cli.py
@@ -96,7 +96,7 @@ def main(original_args=None):
     files = []
     new_version = None
 
-    args, known_args, root_parser, positionals = _parse_phase_1(original_args)
+    args, known_args, root_parser, positionals = _parse_arguments_phase_1(original_args)
     _setup_logging(known_args.list, known_args.verbose)
     _determine_vcs_usability(VCS, vcs_info)
     _determine_current_version(vcs_info, defaults)
@@ -123,7 +123,7 @@ def main(original_args=None):
         _tag_in_vcs(args, vcs, vcs_context)
 
 
-def _parse_phase_1(original_args):
+def _parse_arguments_phase_1(original_args):
     positionals, args = split_args_in_optional_and_positional(
         sys.argv[1:] if original_args is None else original_args
     )

--- a/bumpversion/cli.py
+++ b/bumpversion/cli.py
@@ -97,7 +97,7 @@ def main(original_args=None):
     new_version = None
 
     args, known_args, root_parser, positionals = _parse_phase_1(original_args)
-    _setup_logging(known_args)
+    _setup_logging(known_args.list, known_args.verbose)
     vcs = _determine_vcs_is_usable(vcs_info)
     _determine_current_version(defaults, vcs_info)
     config_file, explicit_config = _determine_config_file(known_args)
@@ -162,16 +162,16 @@ def _parse_phase_1(original_args):
     return args, known_args, root_parser, positionals
 
 
-def _setup_logging(known_args):
+def _setup_logging(show_list, verbose):
     logformatter = logging.Formatter("%(message)s")
     if len(logger_list.handlers) == 0:
         ch2 = logging.StreamHandler(sys.stdout)
         ch2.setFormatter(logformatter)
         logger_list.addHandler(ch2)
-    if known_args.list:
+    if show_list:
         logger_list.setLevel(logging.DEBUG)
     try:
-        log_level = [logging.WARNING, logging.INFO, logging.DEBUG][known_args.verbose]
+        log_level = [logging.WARNING, logging.INFO, logging.DEBUG][verbose]
     except IndexError:
         log_level = logging.DEBUG
     root_logger = logging.getLogger('')

--- a/bumpversion/cli.py
+++ b/bumpversion/cli.py
@@ -102,30 +102,19 @@ def main(original_args=None):
     config_file, explicit_config = _determine_config_file(known_args)
     config, config_file_exists = _load_configuration(config_file, defaults, explicit_config, files, part_configs)
     known_args, parser2, remaining_argv = _parse_phase_2(args, defaults, known_args, root_parser)
-
-    context = dict(
-        list(time_context.items())
-        + list(prefixed_environ().items())
-        + list(vcs_info.items())
-    )
-
-    try:
-        vc = VersionConfig(
-            parse=known_args.parse,
-            serialize=known_args.serialize,
-            search=known_args.search,
-            replace=known_args.replace,
-            part_configs=part_configs,
-        )
-    except sre_constants.error as e:
-        # TODO: use re.error here mayhaps, also: should we log?
-        sys.exit(1)
+    vc = _setup_versionconfig(known_args, part_configs)
 
     current_version = (
         vc.parse(known_args.current_version) if known_args.current_version else None
     )
 
     new_version = None
+
+    context = dict(
+        list(time_context.items())
+        + list(prefixed_environ().items())
+        + list(vcs_info.items())
+    )
 
     if "new_version" not in defaults and known_args.current_version:
         try:
@@ -657,3 +646,18 @@ def _parse_phase_2(args, defaults, known_args, root_parser):
     assert isinstance(known_args.serialize, list), "Argument `serialize` must be a list"
 
     return known_args, parser2, remaining_argv
+
+
+def _setup_versionconfig(known_args, part_configs):
+    try:
+        vc = VersionConfig(
+            parse=known_args.parse,
+            serialize=known_args.serialize,
+            search=known_args.search,
+            replace=known_args.replace,
+            part_configs=part_configs,
+        )
+    except sre_constants.error as e:
+        # TODO: use re.error here mayhaps, also: should we log?
+        sys.exit(1)
+    return vc

--- a/bumpversion/cli.py
+++ b/bumpversion/cli.py
@@ -570,12 +570,11 @@ def _determine_vcs_dirty(possible_vcses, defaults):
     return None
 
 
-def _check_files_contain_version(context, current_version, files):
+def _check_files_contain_version(files, current_version, context):
     # make sure files exist and contain version string
     logger.info(
-        "Asserting files {} contain the version string:".format(
-            ", ".join([str(f) for f in files])
-        )
+        "Asserting files %s contain the version string...",
+        ", ".join([str(f) for f in files]),
     )
     for f in files:
         f.should_contain_version(current_version, context)

--- a/bumpversion/cli.py
+++ b/bumpversion/cli.py
@@ -90,15 +90,12 @@ def split_args_in_optional_and_positional(args):
 
 
 def main(original_args=None):
-    args, known_args, root_parser, positionals = _parse_phase_1(original_args)
-    _setup_logging(known_args)
-
     defaults = {}
     vcs_info = {}
 
-    for vcs in VCS:
-        if vcs.is_usable():
-            vcs_info.update(vcs.latest_tag_info())
+    args, known_args, root_parser, positionals = _parse_phase_1(original_args)
+    _setup_logging(known_args)
+    vcs = _determine_vcs_is_usable(vcs_info)
 
     if "current_version" in vcs_info:
         defaults["current_version"] = vcs_info["current_version"]
@@ -588,6 +585,13 @@ def main(original_args=None):
 
     if do_tag:
         vcs.tag(sign_tags, tag_name, tag_message)
+
+
+def _determine_vcs_is_usable(vcs_info):
+    for vcs in VCS:
+        if vcs.is_usable():
+            vcs_info.update(vcs.latest_tag_info())
+    return vcs
 
 
 def _parse_phase_1(original_args):

--- a/bumpversion/cli.py
+++ b/bumpversion/cli.py
@@ -109,11 +109,7 @@ def main(original_args=None):
     new_version = _assemble_new_version(context, current_version, defaults, known_args, new_version, positionals, vc)
     args, file_names = _parse_phase_3(args, defaults, parser2, positionals, remaining_argv)
     new_version = _parse_new_version(args, new_version, vc)
-
-    file_names = file_names or positionals[1:]
-
-    for file_name in file_names:
-        files.append(ConfiguredFile(file_name, vc))
+    _determine_files(file_names, files, positionals, vc)
 
     for vcs in VCS:
         if vcs.is_usable():
@@ -667,3 +663,9 @@ def _parse_new_version(args, new_version, vc):
         new_version = vc.parse(args.new_version)
     logger.info("New version will be '{}'".format(args.new_version))
     return new_version
+
+
+def _determine_files(file_names, files, positionals, vc):
+    file_names = file_names or positionals[1:]
+    for file_name in file_names:
+        files.append(ConfiguredFile(file_name, vc))

--- a/bumpversion/cli.py
+++ b/bumpversion/cli.py
@@ -92,146 +92,15 @@ def split_args_in_optional_and_positional(args):
 def main(original_args=None):
     defaults = {}
     vcs_info = {}
+    part_configs = {}
+    files = []
 
     args, known_args, root_parser, positionals = _parse_phase_1(original_args)
     _setup_logging(known_args)
     vcs = _determine_vcs_is_usable(vcs_info)
     _determine_current_version(defaults, vcs_info)
     config_file, explicit_config = _determine_config_file(known_args)
-
-    # setup.cfg supports interpolation - for compatibility we must do the same.
-    if os.path.basename(config_file) == "setup.cfg":
-        config = ConfigParser("")
-    else:
-        config = RawConfigParser("")
-
-    # don't transform keys to lowercase (which would be the default)
-    config.optionxform = lambda option: option
-
-    config.add_section("bumpversion")
-
-    config_file_exists = os.path.exists(config_file)
-
-    part_configs = {}
-
-    files = []
-
-    if config_file_exists:
-
-        logger.info("Reading config file %s:", config_file)
-        # TODO: this is a DEBUG level log
-        with io.open(config_file, "rt", encoding="utf-8") as f:
-            logger.info(f.read())
-            config_new_lines = f.newlines
-
-        try:
-            # TODO: we're reading the config file twice.
-            config.read_file(io.open(config_file, "rt", encoding="utf-8"))
-        except AttributeError:
-            # python 2 standard ConfigParser doesn't have read_file,
-            # only deprecated readfp
-            config.readfp(io.open(config_file, "rt", encoding="utf-8"))
-
-        log_config = StringIO()
-        config.write(log_config)
-
-        if "files" in dict(config.items("bumpversion")):
-            warnings.warn(
-                "'files =' configuration will be deprecated, please use [bumpversion:file:...]",
-                PendingDeprecationWarning,
-            )
-
-        defaults.update(dict(config.items("bumpversion")))
-
-        for listvaluename in ("serialize",):
-            try:
-                value = config.get("bumpversion", listvaluename)
-                defaults[listvaluename] = list(
-                    filter(None, (x.strip() for x in value.splitlines()))
-                )
-            except NoOptionError:
-                pass  # no default value then ;)
-
-        for boolvaluename in ("commit", "tag", "dry_run"):
-            try:
-                defaults[boolvaluename] = config.getboolean(
-                    "bumpversion", boolvaluename
-                )
-            except NoOptionError:
-                pass  # no default value then ;)
-
-        for section_name in config.sections():
-
-            section_name_match = re.compile("^bumpversion:(file|part):(.+)").match(
-                section_name
-            )
-
-            if not section_name_match:
-                continue
-
-            section_prefix, section_value = section_name_match.groups()
-
-            section_config = dict(config.items(section_name))
-
-            if section_prefix == "part":
-
-                ThisVersionPartConfiguration = NumericVersionPartConfiguration
-
-                if "values" in section_config:
-                    section_config["values"] = list(
-                        filter(
-                            None,
-                            (x.strip() for x in section_config["values"].splitlines()),
-                        )
-                    )
-                    ThisVersionPartConfiguration = ConfiguredVersionPartConfiguration
-
-                part_configs[section_value] = ThisVersionPartConfiguration(
-                    **section_config
-                )
-
-            elif section_prefix == "file":
-
-                filename = section_value
-
-                if "serialize" in section_config:
-                    section_config["serialize"] = list(
-                        filter(
-                            None,
-                            (
-                                x.strip().replace("\\n", "\n")
-                                for x in section_config["serialize"].splitlines()
-                            ),
-                        )
-                    )
-
-                section_config["part_configs"] = part_configs
-
-                if "parse" not in section_config:
-                    section_config["parse"] = defaults.get(
-                        "parse", r"(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)"
-                    )
-
-                if "serialize" not in section_config:
-                    section_config["serialize"] = defaults.get(
-                        "serialize", [str("{major}.{minor}.{patch}")]
-                    )
-
-                if "search" not in section_config:
-                    section_config["search"] = defaults.get(
-                        "search", "{current_version}"
-                    )
-
-                if "replace" not in section_config:
-                    section_config["replace"] = defaults.get("replace", "{new_version}")
-
-                files.append(ConfiguredFile(filename, VersionConfig(**section_config)))
-
-    else:
-        message = "Could not read config file at {}".format(config_file)
-        if explicit_config:
-            raise argparse.ArgumentTypeError(message)
-        logger.info(message)
+    config, config_file_exists = _load_configuration(config_file, defaults, explicit_config, files, part_configs)
 
     parser2 = argparse.ArgumentParser(
         prog="bumpversion", add_help=False, parents=[root_parser]
@@ -657,3 +526,131 @@ def _determine_config_file(known_args):
     else:
         config_file = ".bumpversion.cfg"
     return config_file, explicit_config
+
+
+
+def _load_configuration(config_file, defaults, explicit_config, files, part_configs):
+    # setup.cfg supports interpolation - for compatibility we must do the same.
+    if os.path.basename(config_file) == "setup.cfg":
+        config = ConfigParser("")
+    else:
+        config = RawConfigParser("")
+    # don't transform keys to lowercase (which would be the default)
+    config.optionxform = lambda option: option
+    config.add_section("bumpversion")
+    config_file_exists = os.path.exists(config_file)
+    if config_file_exists:
+
+        logger.info("Reading config file {}:".format(config_file))
+        # TODO: this is a DEBUG level log
+        logger.info(io.open(config_file, "rt", encoding="utf-8").read())
+
+        try:
+            # TODO: we're reading the config file twice.
+            config.read_file(io.open(config_file, "rt", encoding="utf-8"))
+        except AttributeError:
+            # python 2 standard ConfigParser doesn't have read_file,
+            # only deprecated readfp
+            config.readfp(io.open(config_file, "rt", encoding="utf-8"))
+
+        log_config = StringIO()
+        config.write(log_config)
+
+        if "files" in dict(config.items("bumpversion")):
+            warnings.warn(
+                "'files =' configuration will be deprecated, please use [bumpversion:file:...]",
+                PendingDeprecationWarning,
+            )
+
+        defaults.update(dict(config.items("bumpversion")))
+
+        for listvaluename in ("serialize",):
+            try:
+                value = config.get("bumpversion", listvaluename)
+                defaults[listvaluename] = list(
+                    filter(None, (x.strip() for x in value.splitlines()))
+                )
+            except NoOptionError:
+                pass  # no default value then ;)
+
+        for boolvaluename in ("commit", "tag", "dry_run"):
+            try:
+                defaults[boolvaluename] = config.getboolean(
+                    "bumpversion", boolvaluename
+                )
+            except NoOptionError:
+                pass  # no default value then ;)
+
+        for section_name in config.sections():
+
+            section_name_match = re.compile("^bumpversion:(file|part):(.+)").match(
+                section_name
+            )
+
+            if not section_name_match:
+                continue
+
+            section_prefix, section_value = section_name_match.groups()
+
+            section_config = dict(config.items(section_name))
+
+            if section_prefix == "part":
+
+                ThisVersionPartConfiguration = NumericVersionPartConfiguration
+
+                if "values" in section_config:
+                    section_config["values"] = list(
+                        filter(
+                            None,
+                            (x.strip() for x in section_config["values"].splitlines()),
+                        )
+                    )
+                    ThisVersionPartConfiguration = ConfiguredVersionPartConfiguration
+
+                part_configs[section_value] = ThisVersionPartConfiguration(
+                    **section_config
+                )
+
+            elif section_prefix == "file":
+
+                filename = section_value
+
+                if "serialize" in section_config:
+                    section_config["serialize"] = list(
+                        filter(
+                            None,
+                            (
+                                x.strip().replace("\\n", "\n")
+                                for x in section_config["serialize"].splitlines()
+                            ),
+                        )
+                    )
+
+                section_config["part_configs"] = part_configs
+
+                if "parse" not in section_config:
+                    section_config["parse"] = defaults.get(
+                        "parse", r"(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)"
+                    )
+
+                if "serialize" not in section_config:
+                    section_config["serialize"] = defaults.get(
+                        "serialize", [str("{major}.{minor}.{patch}")]
+                    )
+
+                if "search" not in section_config:
+                    section_config["search"] = defaults.get(
+                        "search", "{current_version}"
+                    )
+
+                if "replace" not in section_config:
+                    section_config["replace"] = defaults.get("replace", "{new_version}")
+
+                files.append(ConfiguredFile(filename, VersionConfig(**section_config)))
+
+    else:
+        message = "Could not read config file at {}".format(config_file)
+        if explicit_config:
+            raise argparse.ArgumentTypeError(message)
+        logger.info(message)
+    return config, config_file_exists

--- a/bumpversion/cli.py
+++ b/bumpversion/cli.py
@@ -104,7 +104,7 @@ def main(original_args=None):
     if hasattr(known_args, "config_file"):
         explicit_config = known_args.config_file
     config_file = _determine_config_file(explicit_config)
-    config, config_file_exists = _load_configuration(config_file, defaults, explicit_config, files, part_configs)
+    config, config_file_exists = _load_configuration(config_file, explicit_config, files, defaults, part_configs)
     known_args, parser2, remaining_argv = _parse_phase_2(args, defaults, known_args, root_parser)
     vc = _setup_versionconfig(known_args, part_configs)
     current_version = _parse_current_version(known_args.current_version, vc)
@@ -188,7 +188,7 @@ def _determine_vcs_usability(possible_vcses, vcs_info):
             vcs_info.update(vcs.latest_tag_info())
 
 
-def _determine_current_version(defaults, vcs_info):
+def _determine_current_version(vcs_info, defaults):
     if "current_version" in vcs_info:
         defaults["current_version"] = vcs_info["current_version"]
 
@@ -201,7 +201,7 @@ def _determine_config_file(explicit_config):
     return ".bumpversion.cfg"
 
 
-def _load_configuration(config_file, defaults, explicit_config, files, part_configs):
+def _load_configuration(config_file, explicit_config, files, defaults, part_configs):
     # setup.cfg supports interpolation - for compatibility we must do the same.
     if os.path.basename(config_file) == "setup.cfg":
         config = ConfigParser("")

--- a/bumpversion/cli.py
+++ b/bumpversion/cli.py
@@ -106,20 +106,7 @@ def main(original_args=None):
     vc = _setup_versionconfig(known_args, part_configs)
     current_version = _update_current_version(known_args, vc)
     context = _assemble_context(vcs_info)
-
-    if "new_version" not in defaults and known_args.current_version:
-        try:
-            if current_version and positionals:
-                logger.info("Attempting to increment part '%s'", positionals[0])
-                new_version = current_version.bump(positionals[0], vc.order())
-                logger.info("Values are now: %s", keyvaluestring(new_version._values))
-                defaults["new_version"] = vc.serialize(new_version, context)
-        except MissingValueForSerializationException as e:
-            logger.info("Opportunistic finding of new_version failed: %s", e.message)
-        except IncompleteVersionRepresentationException as e:
-            logger.info("Opportunistic finding of new_version failed: %s", e.message)
-        except KeyError as e:
-            logger.info("Opportunistic finding of new_version failed")
+    new_version = _assemble_new_version(context, current_version, defaults, known_args, new_version, positionals, vc)
 
     parser3 = argparse.ArgumentParser(
         prog="bumpversion",
@@ -380,6 +367,23 @@ def main(original_args=None):
 
     if do_tag:
         vcs.tag(sign_tags, tag_name, tag_message)
+
+
+def _assemble_new_version(context, current_version, defaults, known_args, new_version, positionals, vc):
+    if "new_version" not in defaults and known_args.current_version:
+        try:
+            if current_version and len(positionals) > 0:
+                logger.info("Attempting to increment part '{}'".format(positionals[0]))
+                new_version = current_version.bump(positionals[0], vc.order())
+                logger.info("Values are now: " + keyvaluestring(new_version._values))
+                defaults["new_version"] = vc.serialize(new_version, context)
+        except MissingValueForSerializationException as e:
+            logger.info("Opportunistic finding of new_version failed: " + e.message)
+        except IncompleteVersionRepresentationException as e:
+            logger.info("Opportunistic finding of new_version failed: " + e.message)
+        except KeyError as e:
+            logger.info("Opportunistic finding of new_version failed")
+    return new_version
 
 
 def _parse_phase_1(original_args):

--- a/bumpversion/cli.py
+++ b/bumpversion/cli.py
@@ -110,7 +110,7 @@ def main(original_args=None):
     current_version = _parse_current_version(known_args.current_version, vc)
     context = _assemble_context(vcs_info)
     new_version = _assemble_new_version(context, current_version, defaults, known_args.current_version, new_version, positionals, vc)
-    args, file_names = _parse_phase_3(defaults, parser2, positionals, remaining_argv)
+    args, file_names = _parse_arguments_phase_3(remaining_argv, positionals, defaults, parser2)
     new_version = _parse_new_version(args, new_version, vc)
     _determine_files(file_names, files, positionals, vc)
     vcs = _determine_vcs_dirty(VCS, defaults)
@@ -423,7 +423,7 @@ def _assemble_new_version(context, current_version, defaults, arg_current_versio
     return new_version
 
 
-def _parse_phase_3(defaults, parser2, positionals, remaining_argv):
+def _parse_arguments_phase_3(remaining_argv, positionals, defaults, parser2):
     parser3 = argparse.ArgumentParser(
         prog="bumpversion",
         description=DESCRIPTION,

--- a/bumpversion/cli.py
+++ b/bumpversion/cli.py
@@ -96,7 +96,7 @@ def main(original_args=None):
     _log_list(config, args.new_version)
     _update_config_file(config, config_file, config_file_exists, args.new_version, args.dry_run)
     if vcs:
-        vcs_context = _commit_to_vcs(args, config_file, config_file_exists, files, vcs)
+        vcs_context = _commit_to_vcs(files, config_file, config_file_exists, vcs, args)
         _tag_in_vcs(args, vcs, vcs_context)
 
 
@@ -619,7 +619,7 @@ def _update_config_file(config, config_file, config_file_exists, new_version, dr
         )
 
 
-def _commit_to_vcs(args, config_file, config_file_exists, files, vcs):
+def _commit_to_vcs(files, config_file, config_file_exists, vcs, args):
     commit_files = [f.path for f in files]
     if config_file_exists:
         commit_files.append(config_file)

--- a/bumpversion/cli.py
+++ b/bumpversion/cli.py
@@ -110,21 +110,7 @@ def main(original_args=None):
     args, file_names = _parse_phase_3(args, defaults, parser2, positionals, remaining_argv)
     new_version = _parse_new_version(args, new_version, vc)
     _determine_files(file_names, files, positionals, vc)
-
-    for vcs in VCS:
-        if vcs.is_usable():
-            try:
-                vcs.assert_nondirty()
-            except WorkingDirectoryIsDirtyException as e:
-                if not defaults["allow_dirty"]:
-                    logger.warning(
-                        "%s\n\nUse --allow-dirty to override this if you know what you're doing.",
-                        e.message
-                    )
-                    raise
-            break
-        else:
-            vcs = None
+    vcs = _determine_vcs_dirty(defaults, vcs)
 
     # make sure files exist and contain version string
 
@@ -669,3 +655,22 @@ def _determine_files(file_names, files, positionals, vc):
     file_names = file_names or positionals[1:]
     for file_name in file_names:
         files.append(ConfiguredFile(file_name, vc))
+
+
+def _determine_vcs_dirty(defaults, vcs):
+    for vcs in VCS:
+        if vcs.is_usable():
+            try:
+                vcs.assert_nondirty()
+            except WorkingDirectoryIsDirtyException as e:
+                if not defaults["allow_dirty"]:
+                    logger.warning(
+                        "{}\n\nUse --allow-dirty to override this if you know what you're doing.".format(
+                            e.message
+                        )
+                    )
+                    raise
+            break
+        else:
+            vcs = None
+    return vcs

--- a/bumpversion/cli.py
+++ b/bumpversion/cli.py
@@ -107,128 +107,7 @@ def main(original_args=None):
     current_version = _update_current_version(known_args, vc)
     context = _assemble_context(vcs_info)
     new_version = _assemble_new_version(context, current_version, defaults, known_args, new_version, positionals, vc)
-
-    parser3 = argparse.ArgumentParser(
-        prog="bumpversion",
-        description=DESCRIPTION,
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
-        conflict_handler="resolve",
-        parents=[parser2],
-    )
-
-    parser3.set_defaults(**defaults)
-
-    parser3.add_argument(
-        "--current-version",
-        metavar="VERSION",
-        help="Version that needs to be updated",
-        required="current_version" not in defaults,
-    )
-    parser3.add_argument(
-        "--dry-run",
-        "-n",
-        action="store_true",
-        default=False,
-        help="Don't write any files, just pretend.",
-    )
-    parser3.add_argument(
-        "--new-version",
-        metavar="VERSION",
-        help="New version that should be in the files",
-        required="new_version" not in defaults,
-    )
-
-    commitgroup = parser3.add_mutually_exclusive_group()
-
-    commitgroup.add_argument(
-        "--commit",
-        action="store_true",
-        dest="commit",
-        help="Commit to version control",
-        default=defaults.get("commit", False),
-    )
-    commitgroup.add_argument(
-        "--no-commit",
-        action="store_false",
-        dest="commit",
-        help="Do not commit to version control",
-        default=argparse.SUPPRESS,
-    )
-
-    taggroup = parser3.add_mutually_exclusive_group()
-
-    taggroup.add_argument(
-        "--tag",
-        action="store_true",
-        dest="tag",
-        default=defaults.get("tag", False),
-        help="Create a tag in version control",
-    )
-    taggroup.add_argument(
-        "--no-tag",
-        action="store_false",
-        dest="tag",
-        help="Do not create a tag in version control",
-        default=argparse.SUPPRESS,
-    )
-
-    signtagsgroup = parser3.add_mutually_exclusive_group()
-    signtagsgroup.add_argument(
-        "--sign-tags",
-        action="store_true",
-        dest="sign_tags",
-        help="Sign tags if created",
-        default=defaults.get("sign_tags", False),
-    )
-    signtagsgroup.add_argument(
-        "--no-sign-tags",
-        action="store_false",
-        dest="sign_tags",
-        help="Do not sign tags if created",
-        default=argparse.SUPPRESS,
-    )
-
-    parser3.add_argument(
-        "--tag-name",
-        metavar="TAG_NAME",
-        help="Tag name (only works with --tag)",
-        default=defaults.get("tag_name", "v{new_version}"),
-    )
-
-    parser3.add_argument(
-        "--tag-message",
-        metavar="TAG_MESSAGE",
-        dest="tag_message",
-        help="Tag message",
-        default=defaults.get(
-            "tag_message", "Bump version: {current_version} → {new_version}"
-        ),
-    )
-
-    parser3.add_argument(
-        "--message",
-        "-m",
-        metavar="COMMIT_MSG",
-        help="Commit message",
-        default=defaults.get(
-            "message", "Bump version: {current_version} → {new_version}"
-        ),
-    )
-
-    file_names = []
-    if "files" in defaults:
-        assert defaults["files"] is not None
-        file_names = defaults["files"].split(" ")
-
-    parser3.add_argument("part", help="Part of the version to be bumped.")
-    parser3.add_argument(
-        "files", metavar="file", nargs="*", help="Files to change", default=file_names
-    )
-
-    args = parser3.parse_args(remaining_argv + positionals)
-
-    if args.dry_run:
-        logger.info("Dry run active, won't touch any files.")
+    args, file_names = _parse_phase_3(args, defaults, parser2, positionals, remaining_argv)
 
     if args.new_version:
         new_version = vc.parse(args.new_version)
@@ -672,3 +551,116 @@ def _assemble_context(vcs_info):
         + list(vcs_info.items())
     )
     return context
+
+
+def _parse_phase_3(args, defaults, parser2, positionals, remaining_argv):
+    parser3 = argparse.ArgumentParser(
+        prog="bumpversion",
+        description=DESCRIPTION,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        conflict_handler="resolve",
+        parents=[parser2],
+    )
+    parser3.set_defaults(**defaults)
+    parser3.add_argument(
+        "--current-version",
+        metavar="VERSION",
+        help="Version that needs to be updated",
+        required="current_version" not in defaults,
+    )
+    parser3.add_argument(
+        "--dry-run",
+        "-n",
+        action="store_true",
+        default=False,
+        help="Don't write any files, just pretend.",
+    )
+    parser3.add_argument(
+        "--new-version",
+        metavar="VERSION",
+        help="New version that should be in the files",
+        required="new_version" not in defaults,
+    )
+    commitgroup = parser3.add_mutually_exclusive_group()
+    commitgroup.add_argument(
+        "--commit",
+        action="store_true",
+        dest="commit",
+        help="Commit to version control",
+        default=defaults.get("commit", False),
+    )
+    commitgroup.add_argument(
+        "--no-commit",
+        action="store_false",
+        dest="commit",
+        help="Do not commit to version control",
+        default=argparse.SUPPRESS,
+    )
+    taggroup = parser3.add_mutually_exclusive_group()
+    taggroup.add_argument(
+        "--tag",
+        action="store_true",
+        dest="tag",
+        default=defaults.get("tag", False),
+        help="Create a tag in version control",
+    )
+    taggroup.add_argument(
+        "--no-tag",
+        action="store_false",
+        dest="tag",
+        help="Do not create a tag in version control",
+        default=argparse.SUPPRESS,
+    )
+    signtagsgroup = parser3.add_mutually_exclusive_group()
+    signtagsgroup.add_argument(
+        "--sign-tags",
+        action="store_true",
+        dest="sign_tags",
+        help="Sign tags if created",
+        default=defaults.get("sign_tags", False),
+    )
+    signtagsgroup.add_argument(
+        "--no-sign-tags",
+        action="store_false",
+        dest="sign_tags",
+        help="Do not sign tags if created",
+        default=argparse.SUPPRESS,
+    )
+    parser3.add_argument(
+        "--tag-name",
+        metavar="TAG_NAME",
+        help="Tag name (only works with --tag)",
+        default=defaults.get("tag_name", "v{new_version}"),
+    )
+    parser3.add_argument(
+        "--tag-message",
+        metavar="TAG_MESSAGE",
+        dest="tag_message",
+        help="Tag message",
+        default=defaults.get(
+            "tag_message", "Bump version: {current_version} → {new_version}"
+        ),
+    )
+    parser3.add_argument(
+        "--message",
+        "-m",
+        metavar="COMMIT_MSG",
+        help="Commit message",
+        default=defaults.get(
+            "message", "Bump version: {current_version} → {new_version}"
+        ),
+    )
+    file_names = []
+    if "files" in defaults:
+        assert defaults["files"] is not None
+        file_names = defaults["files"].split(" ")
+    parser3.add_argument("part", help="Part of the version to be bumped.")
+    parser3.add_argument(
+        "files", metavar="file", nargs="*", help="Files to change", default=file_names
+    )
+    args = parser3.parse_args(remaining_argv + positionals)
+
+    if args.dry_run:
+        logger.info("Dry run active, won't touch any files.")
+
+    return args, file_names

--- a/bumpversion/cli.py
+++ b/bumpversion/cli.py
@@ -96,9 +96,7 @@ def main(original_args=None):
     args, known_args, root_parser, positionals = _parse_phase_1(original_args)
     _setup_logging(known_args)
     vcs = _determine_vcs_is_usable(vcs_info)
-
-    if "current_version" in vcs_info:
-        defaults["current_version"] = vcs_info["current_version"]
+    _determine_current_version(defaults, vcs_info)
 
     explicit_config = hasattr(known_args, "config_file")
 
@@ -585,6 +583,11 @@ def main(original_args=None):
 
     if do_tag:
         vcs.tag(sign_tags, tag_name, tag_message)
+
+
+def _determine_current_version(defaults, vcs_info):
+    if "current_version" in vcs_info:
+        defaults["current_version"] = vcs_info["current_version"]
 
 
 def _determine_vcs_is_usable(vcs_info):

--- a/bumpversion/cli.py
+++ b/bumpversion/cli.py
@@ -66,29 +66,6 @@ OPTIONAL_ARGUMENTS_THAT_TAKE_VALUES = [
 ]
 
 
-def split_args_in_optional_and_positional(args):
-    # manually parsing positional arguments because stupid argparse can't mix
-    # positional and optional arguments
-
-    positions = []
-    for i, arg in enumerate(args):
-
-        previous = None
-
-        if i > 0:
-            previous = args[i - 1]
-
-        if (not arg.startswith("-")) and (
-            previous not in OPTIONAL_ARGUMENTS_THAT_TAKE_VALUES
-        ):
-            positions.append(i)
-
-    positionals = [arg for i, arg in enumerate(args) if i in positions]
-    args = [arg for i, arg in enumerate(args) if i not in positions]
-
-    return (positionals, args)
-
-
 def main(original_args=None):
     defaults = {}
     vcs_info = {}
@@ -121,6 +98,29 @@ def main(original_args=None):
     if vcs:
         vcs_context = _commit_to_vcs(args, config_file, config_file_exists, files, vcs)
         _tag_in_vcs(args, vcs, vcs_context)
+
+
+def split_args_in_optional_and_positional(args):
+    # manually parsing positional arguments because stupid argparse can't mix
+    # positional and optional arguments
+
+    positions = []
+    for i, arg in enumerate(args):
+
+        previous = None
+
+        if i > 0:
+            previous = args[i - 1]
+
+        if (not arg.startswith("-")) and (
+            previous not in OPTIONAL_ARGUMENTS_THAT_TAKE_VALUES
+        ):
+            positions.append(i)
+
+    positionals = [arg for i, arg in enumerate(args) if i in positions]
+    args = [arg for i, arg in enumerate(args) if i not in positions]
+
+    return (positionals, args)
 
 
 def _parse_arguments_phase_1(original_args):

--- a/bumpversion/cli.py
+++ b/bumpversion/cli.py
@@ -90,53 +90,7 @@ def split_args_in_optional_and_positional(args):
 
 
 def main(original_args=None):
-
-    positionals, args = split_args_in_optional_and_positional(
-        sys.argv[1:] if original_args is None else original_args
-    )
-
-    if len(positionals[1:]) > 2:
-        warnings.warn(
-            "Giving multiple files on the command line will be deprecated,"
-            " please use [bumpversion:file:...] in a config file.",
-            PendingDeprecationWarning,
-        )
-
-    parser1 = argparse.ArgumentParser(add_help=False)
-
-    parser1.add_argument(
-        "--config-file",
-        metavar="FILE",
-        default=argparse.SUPPRESS,
-        required=False,
-        help="Config file to read most of the variables from (default: .bumpversion.cfg)",
-    )
-
-    parser1.add_argument(
-        "--verbose",
-        action="count",
-        default=0,
-        help="Print verbose logging to stderr",
-        required=False,
-    )
-
-    parser1.add_argument(
-        "--list",
-        action="store_true",
-        default=False,
-        help="List machine readable information",
-        required=False,
-    )
-
-    parser1.add_argument(
-        "--allow-dirty",
-        action="store_true",
-        default=False,
-        help="Don't abort if working directory is dirty",
-        required=False,
-    )
-
-    known_args, remaining_argv = parser1.parse_known_args(args)
+    args, known_args, parser1, positionals = _parse_phase_1(original_args)
 
     logformatter = logging.Formatter("%(message)s")
 
@@ -653,3 +607,45 @@ def main(original_args=None):
 
     if do_tag:
         vcs.tag(sign_tags, tag_name, tag_message)
+
+
+def _parse_phase_1(original_args):
+    positionals, args = split_args_in_optional_and_positional(
+        sys.argv[1:] if original_args is None else original_args
+    )
+    if len(positionals[1:]) > 2:
+        warnings.warn(
+            "Giving multiple files on the command line will be deprecated, please use [bumpversion:file:...] in a config file.",
+            PendingDeprecationWarning,
+        )
+    parser1 = argparse.ArgumentParser(add_help=False)
+    parser1.add_argument(
+        "--config-file",
+        metavar="FILE",
+        default=argparse.SUPPRESS,
+        required=False,
+        help="Config file to read most of the variables from (default: .bumpversion.cfg)",
+    )
+    parser1.add_argument(
+        "--verbose",
+        action="count",
+        default=0,
+        help="Print verbose logging to stderr",
+        required=False,
+    )
+    parser1.add_argument(
+        "--list",
+        action="store_true",
+        default=False,
+        help="List machine readable information",
+        required=False,
+    )
+    parser1.add_argument(
+        "--allow-dirty",
+        action="store_true",
+        default=False,
+        help="Don't abort if working directory is dirty",
+        required=False,
+    )
+    known_args, remaining_argv = parser1.parse_known_args(args)
+    return args, known_args, parser1, positionals

--- a/bumpversion/cli.py
+++ b/bumpversion/cli.py
@@ -119,22 +119,7 @@ def main(original_args=None):
         return
 
     vcs_context = _commit_to_vcs(args, config_file, config_file_exists, files, vcs)
-
-    sign_tags = args.sign_tags
-    tag_name = args.tag_name.format(**vcs_context)
-    tag_message = args.tag_message.format(**vcs_context)
-    do_tag = args.tag and not args.dry_run
-    logger.info(
-        "%s '%s' %s in %s and %s",
-        "Would tag" if not do_tag else "Tagging",
-        tag_name,
-        "with message '{}'".format(tag_message) if tag_message else "without message",
-        vcs.__name__,
-        "signing" if sign_tags else "not signing",
-    )
-
-    if do_tag:
-        vcs.tag(sign_tags, tag_name, tag_message)
+    _tag_in_vcs(args, vcs, vcs_context)
 
 
 def _parse_phase_1(original_args):
@@ -676,3 +661,22 @@ def _commit_to_vcs(args, config_file, config_file_exists, files, vcs):
     if do_commit:
         vcs.commit(message=commit_message)
     return vcs_context
+
+
+def _tag_in_vcs(args, vcs, vcs_context):
+    sign_tags = args.sign_tags
+    tag_name = args.tag_name.format(**vcs_context)
+    tag_message = args.tag_message.format(**vcs_context)
+    do_tag = args.tag and not args.dry_run
+    logger.info(
+        "{} '{}' {} in {} and {}".format(
+            "Would tag" if not do_tag else "Tagging",
+            tag_name,
+            "with message '{}'".format(tag_message) if tag_message else "without message",
+            vcs.__name__,
+            "signing" if sign_tags else "not signing",
+        )
+    )
+    if do_tag:
+        vcs.tag(sign_tags, tag_name, tag_message)
+

--- a/bumpversion/cli.py
+++ b/bumpversion/cli.py
@@ -113,15 +113,7 @@ def main(original_args=None):
     vcs = _determine_vcs_dirty(defaults, vcs)
     _check_files_contain_version(context, current_version, files)
     _replace_version_in_files(args, context, current_version, files, new_version)
-
-    commit_files = [f.path for f in files]
-
-    config.set("bumpversion", "new_version", args.new_version)
-
-    for key, value in config.items("bumpversion"):
-        logger_list.info("%s=%s", key, value)
-
-    config.remove_option("bumpversion", "new_version")
+    _log_list(args, config)
 
     config.set("bumpversion", "current_version", args.new_version)
 
@@ -149,6 +141,7 @@ def main(original_args=None):
             "Update with `pip install --upgrade configparser`."
         )
 
+    commit_files = [f.path for f in files]
     if config_file_exists:
         commit_files.append(config_file)
 
@@ -679,3 +672,10 @@ def _replace_version_in_files(args, context, current_version, files, new_version
     # change version string in files
     for f in files:
         f.replace(current_version, new_version, context, args.dry_run)
+
+
+def _log_list(args, config):
+    config.set("bumpversion", "new_version", args.new_version)
+    for key, value in config.items("bumpversion"):
+        logger_list.info("{}={}".format(key, value))
+    config.remove_option("bumpversion", "new_version")

--- a/bumpversion/cli.py
+++ b/bumpversion/cli.py
@@ -99,7 +99,7 @@ def main(original_args=None):
     args, known_args, root_parser, positionals = _parse_phase_1(original_args)
     _setup_logging(known_args.list, known_args.verbose)
     _determine_vcs_usability(VCS, vcs_info)
-    _determine_current_version(defaults, vcs_info)
+    _determine_current_version(vcs_info, defaults)
     explicit_config = None
     if hasattr(known_args, "config_file"):
         explicit_config = known_args.config_file

--- a/bumpversion/cli.py
+++ b/bumpversion/cli.py
@@ -228,13 +228,16 @@ def _load_configuration(config_file, explicit_config, files, defaults, part_conf
 
     logger.info("Reading config file %s:", config_file)
     # TODO: this is a DEBUG level log
-    logger.info(io.open(config_file, "rt", encoding="utf-8").read())
+
+    with io.open(config_file, "rt", encoding="utf-8") as config_fp:
+        config_content = config_fp.read()
+
+    logger.info(config_content)
 
     try:
-        # TODO: we're reading the config file twice.
-        config.read_file(io.open(config_file, "rt", encoding="utf-8"))
+        config.read_string(config_content)
     except AttributeError:
-        # python 2 standard ConfigParser doesn't have read_file,
+        # python 2 standard ConfigParser doesn't have read_string,
         # only deprecated readfp
         config.readfp(io.open(config_file, "rt", encoding="utf-8"))
 

--- a/bumpversion/cli.py
+++ b/bumpversion/cli.py
@@ -112,10 +112,7 @@ def main(original_args=None):
     _determine_files(file_names, files, positionals, vc)
     vcs = _determine_vcs_dirty(defaults, vcs)
     _check_files_contain_version(context, current_version, files)
-
-    # change version string in files
-    for f in files:
-        f.replace(current_version, new_version, context, args.dry_run)
+    _replace_version_in_files(args, context, current_version, files, new_version)
 
     commit_files = [f.path for f in files]
 
@@ -676,3 +673,9 @@ def _check_files_contain_version(context, current_version, files):
     )
     for f in files:
         f.should_contain_version(current_version, context)
+
+
+def _replace_version_in_files(args, context, current_version, files, new_version):
+    # change version string in files
+    for f in files:
+        f.replace(current_version, new_version, context, args.dry_run)

--- a/bumpversion/cli.py
+++ b/bumpversion/cli.py
@@ -114,10 +114,11 @@ def main(original_args=None):
     new_version = _parse_new_version(args, new_version, vc)
     _determine_files(file_names, files, positionals, vc)
     vcs = _determine_vcs_dirty(VCS, defaults)
-    _check_files_contain_version(context, current_version, files)
-    _replace_version_in_files(args, context, current_version, files, new_version)
-    _log_list(args, config)
-    _update_config_file(args, config, config_file, config_file_exists)
+    _check_files_contain_version(files, current_version, context)
+    _replace_version_in_files(files, current_version, new_version, args.dry_run, context)
+    _log_list(config, args.new_version)
+    _update_config_file(config, config_file, config_file_exists, args.new_version, args.dry_run)
+
     if vcs:
         vcs_context = _commit_to_vcs(args, config_file, config_file_exists, files, vcs)
         _tag_in_vcs(args, vcs, vcs_context)
@@ -581,10 +582,10 @@ def _check_files_contain_version(context, current_version, files):
         f.should_contain_version(current_version, context)
 
 
-def _replace_version_in_files(args, context, current_version, files, new_version):
+def _replace_version_in_files(files, current_version, new_version, dry_run, context):
     # change version string in files
     for f in files:
-        f.replace(current_version, new_version, context, args.dry_run)
+        f.replace(current_version, new_version, context, dry_run)
 
 
 def _log_list(args, config):

--- a/bumpversion/cli.py
+++ b/bumpversion/cli.py
@@ -90,7 +90,7 @@ def split_args_in_optional_and_positional(args):
 
 
 def main(original_args=None):
-    args, known_args, parser1, positionals = _parse_phase_1(original_args)
+    args, known_args, root_parser, positionals = _parse_phase_1(original_args)
     _setup_logging(known_args)
 
     defaults = {}
@@ -247,7 +247,7 @@ def main(original_args=None):
         logger.info(message)
 
     parser2 = argparse.ArgumentParser(
-        prog="bumpversion", add_help=False, parents=[parser1]
+        prog="bumpversion", add_help=False, parents=[root_parser]
     )
     parser2.set_defaults(**defaults)
 
@@ -599,37 +599,37 @@ def _parse_phase_1(original_args):
             "Giving multiple files on the command line will be deprecated, please use [bumpversion:file:...] in a config file.",
             PendingDeprecationWarning,
         )
-    parser1 = argparse.ArgumentParser(add_help=False)
-    parser1.add_argument(
+    root_parser = argparse.ArgumentParser(add_help=False)
+    root_parser.add_argument(
         "--config-file",
         metavar="FILE",
         default=argparse.SUPPRESS,
         required=False,
         help="Config file to read most of the variables from (default: .bumpversion.cfg)",
     )
-    parser1.add_argument(
+    root_parser.add_argument(
         "--verbose",
         action="count",
         default=0,
         help="Print verbose logging to stderr",
         required=False,
     )
-    parser1.add_argument(
+    root_parser.add_argument(
         "--list",
         action="store_true",
         default=False,
         help="List machine readable information",
         required=False,
     )
-    parser1.add_argument(
+    root_parser.add_argument(
         "--allow-dirty",
         action="store_true",
         default=False,
         help="Don't abort if working directory is dirty",
         required=False,
     )
-    known_args, remaining_argv = parser1.parse_known_args(args)
-    return args, known_args, parser1, positionals
+    known_args, remaining_argv = root_parser.parse_known_args(args)
+    return args, known_args, root_parser, positionals
 
 
 def _setup_logging(known_args):

--- a/bumpversion/cli.py
+++ b/bumpversion/cli.py
@@ -91,26 +91,7 @@ def split_args_in_optional_and_positional(args):
 
 def main(original_args=None):
     args, known_args, parser1, positionals = _parse_phase_1(original_args)
-
-    logformatter = logging.Formatter("%(message)s")
-
-    if not logger_list.handlers:
-        ch2 = logging.StreamHandler(sys.stdout)
-        ch2.setFormatter(logformatter)
-        logger_list.addHandler(ch2)
-
-    if known_args.list:
-        logger_list.setLevel(logging.DEBUG)
-
-    try:
-        log_level = [logging.WARNING, logging.INFO, logging.DEBUG][known_args.verbose]
-    except IndexError:
-        log_level = logging.DEBUG
-
-    root_logger = logging.getLogger('')
-    root_logger.setLevel(log_level)
-
-    logger.debug("Starting %s", DESCRIPTION)
+    _setup_logging(known_args)
 
     defaults = {}
     vcs_info = {}
@@ -649,3 +630,20 @@ def _parse_phase_1(original_args):
     )
     known_args, remaining_argv = parser1.parse_known_args(args)
     return args, known_args, parser1, positionals
+
+
+def _setup_logging(known_args):
+    logformatter = logging.Formatter("%(message)s")
+    if len(logger_list.handlers) == 0:
+        ch2 = logging.StreamHandler(sys.stdout)
+        ch2.setFormatter(logformatter)
+        logger_list.addHandler(ch2)
+    if known_args.list:
+        logger_list.setLevel(logging.DEBUG)
+    try:
+        log_level = [logging.WARNING, logging.INFO, logging.DEBUG][known_args.verbose]
+    except IndexError:
+        log_level = logging.DEBUG
+    root_logger = logging.getLogger('')
+    root_logger.setLevel(log_level)
+    logger.debug("Starting {}".format(DESCRIPTION))

--- a/bumpversion/cli.py
+++ b/bumpversion/cli.py
@@ -101,51 +101,7 @@ def main(original_args=None):
     _determine_current_version(defaults, vcs_info)
     config_file, explicit_config = _determine_config_file(known_args)
     config, config_file_exists = _load_configuration(config_file, defaults, explicit_config, files, part_configs)
-
-    parser2 = argparse.ArgumentParser(
-        prog="bumpversion", add_help=False, parents=[root_parser]
-    )
-    parser2.set_defaults(**defaults)
-
-    parser2.add_argument(
-        "--current-version",
-        metavar="VERSION",
-        help="Version that needs to be updated",
-        required=False,
-    )
-    parser2.add_argument(
-        "--parse",
-        metavar="REGEX",
-        help="Regex parsing the version string",
-        default=defaults.get(
-            "parse", r"(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)"
-        ),
-    )
-    parser2.add_argument(
-        "--serialize",
-        metavar="FORMAT",
-        action=DiscardDefaultIfSpecifiedAppendAction,
-        help="How to format what is parsed back to a version",
-        default=defaults.get("serialize", [str("{major}.{minor}.{patch}")]),
-    )
-    parser2.add_argument(
-        "--search",
-        metavar="SEARCH",
-        help="Template for complete string to search",
-        default=defaults.get("search", "{current_version}"),
-    )
-    parser2.add_argument(
-        "--replace",
-        metavar="REPLACE",
-        help="Template for complete string to replace",
-        default=defaults.get("replace", "{new_version}"),
-    )
-
-    known_args, remaining_argv = parser2.parse_known_args(args)
-
-    defaults.update(vars(known_args))
-
-    assert isinstance(known_args.serialize, list), "Argument `serialize` must be a list"
+    known_args, parser2, remaining_argv = _parse_phase_2(args, defaults, known_args, root_parser)
 
     context = dict(
         list(time_context.items())
@@ -654,3 +610,50 @@ def _load_configuration(config_file, defaults, explicit_config, files, part_conf
             raise argparse.ArgumentTypeError(message)
         logger.info(message)
     return config, config_file_exists
+
+
+def _parse_phase_2(args, defaults, known_args, root_parser):
+    parser2 = argparse.ArgumentParser(
+        prog="bumpversion", add_help=False, parents=[root_parser]
+    )
+    parser2.set_defaults(**defaults)
+    parser2.add_argument(
+        "--current-version",
+        metavar="VERSION",
+        help="Version that needs to be updated",
+        required=False,
+    )
+    parser2.add_argument(
+        "--parse",
+        metavar="REGEX",
+        help="Regex parsing the version string",
+        default=defaults.get(
+            "parse", r"(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)"
+        ),
+    )
+    parser2.add_argument(
+        "--serialize",
+        metavar="FORMAT",
+        action=DiscardDefaultIfSpecifiedAppendAction,
+        help="How to format what is parsed back to a version",
+        default=defaults.get("serialize", [str("{major}.{minor}.{patch}")]),
+    )
+    parser2.add_argument(
+        "--search",
+        metavar="SEARCH",
+        help="Template for complete string to search",
+        default=defaults.get("search", "{current_version}"),
+    )
+    parser2.add_argument(
+        "--replace",
+        metavar="REPLACE",
+        help="Template for complete string to replace",
+        default=defaults.get("replace", "{new_version}"),
+    )
+    known_args, remaining_argv = parser2.parse_known_args(args)
+
+    defaults.update(vars(known_args))
+
+    assert isinstance(known_args.serialize, list), "Argument `serialize` must be a list"
+
+    return known_args, parser2, remaining_argv

--- a/bumpversion/cli.py
+++ b/bumpversion/cli.py
@@ -97,7 +97,7 @@ def main(original_args=None):
     _update_config_file(config, config_file, config_file_exists, args.new_version, args.dry_run)
     if vcs:
         vcs_context = _commit_to_vcs(files, config_file, config_file_exists, vcs, args)
-        _tag_in_vcs(args, vcs, vcs_context)
+        _tag_in_vcs(vcs, vcs_context, args)
 
 
 def split_args_in_optional_and_positional(args):
@@ -660,7 +660,7 @@ def _commit_to_vcs(files, config_file, config_file_exists, vcs, args):
     return vcs_context
 
 
-def _tag_in_vcs(args, vcs, vcs_context):
+def _tag_in_vcs(vcs, vcs_context, args):
     sign_tags = args.sign_tags
     tag_name = args.tag_name.format(**vcs_context)
     tag_message = args.tag_message.format(**vcs_context)
@@ -676,4 +676,3 @@ def _tag_in_vcs(args, vcs, vcs_context):
     )
     if do_tag:
         vcs.tag(sign_tags, tag_name, tag_message)
-

--- a/bumpversion/cli.py
+++ b/bumpversion/cli.py
@@ -98,7 +98,7 @@ def main(original_args=None):
 
     args, known_args, root_parser, positionals = _parse_phase_1(original_args)
     _setup_logging(known_args.list, known_args.verbose)
-    vcs = _determine_vcs_is_usable(vcs_info)
+    _determine_vcs_usability(VCS, vcs_info)
     _determine_current_version(defaults, vcs_info)
     config_file, explicit_config = _determine_config_file(known_args)
     config, config_file_exists = _load_configuration(config_file, defaults, explicit_config, files, part_configs)
@@ -179,11 +179,10 @@ def _setup_logging(show_list, verbose):
     logger.debug("Starting {}".format(DESCRIPTION))
 
 
-def _determine_vcs_is_usable(vcs_info):
-    for vcs in VCS:
+def _determine_vcs_usability(possible_vcses, vcs_info):
+    for vcs in possible_vcses:
         if vcs.is_usable():
             vcs_info.update(vcs.latest_tag_info())
-    return vcs
 
 
 def _determine_current_version(defaults, vcs_info):

--- a/bumpversion/cli.py
+++ b/bumpversion/cli.py
@@ -109,8 +109,8 @@ def main(original_args=None):
     vc = _setup_versionconfig(known_args, part_configs)
     current_version = _parse_current_version(known_args.current_version, vc)
     context = _assemble_context(vcs_info)
-    new_version = _assemble_new_version(context, current_version, defaults, known_args, new_version, positionals, vc)
-    args, file_names = _parse_phase_3(args, defaults, parser2, positionals, remaining_argv)
+    new_version = _assemble_new_version(context, current_version, defaults, known_args.current_version, new_version, positionals, vc)
+    args, file_names = _parse_phase_3(defaults, parser2, positionals, remaining_argv)
     new_version = _parse_new_version(args, new_version, vc)
     _determine_files(file_names, files, positionals, vc)
     vcs = _determine_vcs_dirty(VCS, defaults)
@@ -406,8 +406,8 @@ def _assemble_context(vcs_info):
     return context
 
 
-def _assemble_new_version(context, current_version, defaults, known_args, new_version, positionals, vc):
-    if "new_version" not in defaults and known_args.current_version:
+def _assemble_new_version(context, current_version, defaults, arg_current_version, new_version, positionals, vc):
+    if "new_version" not in defaults and arg_current_version:
         try:
             if current_version and len(positionals) > 0:
                 logger.info("Attempting to increment part '{}'".format(positionals[0]))
@@ -423,7 +423,7 @@ def _assemble_new_version(context, current_version, defaults, known_args, new_ve
     return new_version
 
 
-def _parse_phase_3(args, defaults, parser2, positionals, remaining_argv):
+def _parse_phase_3(defaults, parser2, positionals, remaining_argv):
     parser3 = argparse.ArgumentParser(
         prog="bumpversion",
         description=DESCRIPTION,

--- a/bumpversion/cli.py
+++ b/bumpversion/cli.py
@@ -115,11 +115,9 @@ def main(original_args=None):
     _replace_version_in_files(args, context, current_version, files, new_version)
     _log_list(args, config)
     _update_config_file(args, config, config_file, config_file_exists)
-    if not vcs:
-        return
-
-    vcs_context = _commit_to_vcs(args, config_file, config_file_exists, files, vcs)
-    _tag_in_vcs(args, vcs, vcs_context)
+    if vcs:
+        vcs_context = _commit_to_vcs(args, config_file, config_file_exists, files, vcs)
+        _tag_in_vcs(args, vcs, vcs_context)
 
 
 def _parse_phase_1(original_args):

--- a/bumpversion/cli.py
+++ b/bumpversion/cli.py
@@ -204,7 +204,6 @@ def _determine_config_file(known_args):
     return config_file, explicit_config
 
 
-
 def _load_configuration(config_file, defaults, explicit_config, files, part_configs):
     # setup.cfg supports interpolation - for compatibility we must do the same.
     if os.path.basename(config_file) == "setup.cfg":
@@ -215,120 +214,118 @@ def _load_configuration(config_file, defaults, explicit_config, files, part_conf
     config.optionxform = lambda option: option
     config.add_section("bumpversion")
     config_file_exists = os.path.exists(config_file)
-    if config_file_exists:
 
-        logger.info("Reading config file {}:".format(config_file))
-        # TODO: this is a DEBUG level log
-        logger.info(io.open(config_file, "rt", encoding="utf-8").read())
-
-        try:
-            # TODO: we're reading the config file twice.
-            config.read_file(io.open(config_file, "rt", encoding="utf-8"))
-        except AttributeError:
-            # python 2 standard ConfigParser doesn't have read_file,
-            # only deprecated readfp
-            config.readfp(io.open(config_file, "rt", encoding="utf-8"))
-
-        log_config = StringIO()
-        config.write(log_config)
-
-        if "files" in dict(config.items("bumpversion")):
-            warnings.warn(
-                "'files =' configuration will be deprecated, please use [bumpversion:file:...]",
-                PendingDeprecationWarning,
-            )
-
-        defaults.update(dict(config.items("bumpversion")))
-
-        for listvaluename in ("serialize",):
-            try:
-                value = config.get("bumpversion", listvaluename)
-                defaults[listvaluename] = list(
-                    filter(None, (x.strip() for x in value.splitlines()))
-                )
-            except NoOptionError:
-                pass  # no default value then ;)
-
-        for boolvaluename in ("commit", "tag", "dry_run"):
-            try:
-                defaults[boolvaluename] = config.getboolean(
-                    "bumpversion", boolvaluename
-                )
-            except NoOptionError:
-                pass  # no default value then ;)
-
-        for section_name in config.sections():
-
-            section_name_match = re.compile("^bumpversion:(file|part):(.+)").match(
-                section_name
-            )
-
-            if not section_name_match:
-                continue
-
-            section_prefix, section_value = section_name_match.groups()
-
-            section_config = dict(config.items(section_name))
-
-            if section_prefix == "part":
-
-                ThisVersionPartConfiguration = NumericVersionPartConfiguration
-
-                if "values" in section_config:
-                    section_config["values"] = list(
-                        filter(
-                            None,
-                            (x.strip() for x in section_config["values"].splitlines()),
-                        )
-                    )
-                    ThisVersionPartConfiguration = ConfiguredVersionPartConfiguration
-
-                part_configs[section_value] = ThisVersionPartConfiguration(
-                    **section_config
-                )
-
-            elif section_prefix == "file":
-
-                filename = section_value
-
-                if "serialize" in section_config:
-                    section_config["serialize"] = list(
-                        filter(
-                            None,
-                            (
-                                x.strip().replace("\\n", "\n")
-                                for x in section_config["serialize"].splitlines()
-                            ),
-                        )
-                    )
-
-                section_config["part_configs"] = part_configs
-
-                if "parse" not in section_config:
-                    section_config["parse"] = defaults.get(
-                        "parse", r"(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)"
-                    )
-
-                if "serialize" not in section_config:
-                    section_config["serialize"] = defaults.get(
-                        "serialize", [str("{major}.{minor}.{patch}")]
-                    )
-
-                if "search" not in section_config:
-                    section_config["search"] = defaults.get(
-                        "search", "{current_version}"
-                    )
-
-                if "replace" not in section_config:
-                    section_config["replace"] = defaults.get("replace", "{new_version}")
-
-                files.append(ConfiguredFile(filename, VersionConfig(**section_config)))
-
-    else:
+    if not config_file_exists:
         message = "Could not read config file at {}".format(config_file)
         if explicit_config:
             raise argparse.ArgumentTypeError(message)
         logger.info(message)
+        return config, config_file_exists
+
+    logger.info("Reading config file {}:".format(config_file))
+    # TODO: this is a DEBUG level log
+    logger.info(io.open(config_file, "rt", encoding="utf-8").read())
+
+    try:
+        # TODO: we're reading the config file twice.
+        config.read_file(io.open(config_file, "rt", encoding="utf-8"))
+    except AttributeError:
+        # python 2 standard ConfigParser doesn't have read_file,
+        # only deprecated readfp
+        config.readfp(io.open(config_file, "rt", encoding="utf-8"))
+
+    log_config = StringIO()
+    config.write(log_config)
+
+    if "files" in dict(config.items("bumpversion")):
+        warnings.warn(
+            "'files =' configuration will be deprecated, please use [bumpversion:file:...]",
+            PendingDeprecationWarning,
+        )
+
+    defaults.update(dict(config.items("bumpversion")))
+
+    for listvaluename in ("serialize",):
+        try:
+            value = config.get("bumpversion", listvaluename)
+            defaults[listvaluename] = list(
+                filter(None, (x.strip() for x in value.splitlines()))
+            )
+        except NoOptionError:
+            pass  # no default value then ;)
+
+    for boolvaluename in ("commit", "tag", "dry_run"):
+        try:
+            defaults[boolvaluename] = config.getboolean(
+                "bumpversion", boolvaluename
+            )
+        except NoOptionError:
+            pass  # no default value then ;)
+
+    for section_name in config.sections():
+        section_name_match = re.compile("^bumpversion:(file|part):(.+)").match(
+            section_name
+        )
+
+        if not section_name_match:
+            continue
+
+        section_prefix, section_value = section_name_match.groups()
+
+        section_config = dict(config.items(section_name))
+
+        if section_prefix == "part":
+            ThisVersionPartConfiguration = NumericVersionPartConfiguration
+
+            if "values" in section_config:
+                section_config["values"] = list(
+                    filter(
+                        None,
+                        (x.strip() for x in section_config["values"].splitlines()),
+                    )
+                )
+                ThisVersionPartConfiguration = ConfiguredVersionPartConfiguration
+
+            part_configs[section_value] = ThisVersionPartConfiguration(
+                **section_config
+            )
+
+        elif section_prefix == "file":
+            filename = section_value
+
+            if "serialize" in section_config:
+                section_config["serialize"] = list(
+                    filter(
+                        None,
+                        (
+                            x.strip().replace("\\n", "\n")
+                            for x in section_config["serialize"].splitlines()
+                        ),
+                    )
+                )
+
+            section_config["part_configs"] = part_configs
+
+            if "parse" not in section_config:
+                section_config["parse"] = defaults.get(
+                    "parse", r"(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)"
+                )
+
+            if "serialize" not in section_config:
+                section_config["serialize"] = defaults.get(
+                    "serialize", [str("{major}.{minor}.{patch}")]
+                )
+
+            if "search" not in section_config:
+                section_config["search"] = defaults.get(
+                    "search", "{current_version}"
+                )
+
+            if "replace" not in section_config:
+                section_config["replace"] = defaults.get("replace", "{new_version}")
+
+            files.append(ConfiguredFile(filename, VersionConfig(**section_config)))
+
     return config, config_file_exists
 
 

--- a/bumpversion/cli.py
+++ b/bumpversion/cli.py
@@ -100,7 +100,10 @@ def main(original_args=None):
     _setup_logging(known_args.list, known_args.verbose)
     _determine_vcs_usability(VCS, vcs_info)
     _determine_current_version(defaults, vcs_info)
-    config_file, explicit_config = _determine_config_file(known_args)
+    explicit_config = None
+    if hasattr(known_args, "config_file"):
+        explicit_config = known_args.config_file
+    config_file = _determine_config_file(explicit_config)
     config, config_file_exists = _load_configuration(config_file, defaults, explicit_config, files, part_configs)
     known_args, parser2, remaining_argv = _parse_phase_2(args, defaults, known_args, root_parser)
     vc = _setup_versionconfig(known_args, part_configs)
@@ -190,15 +193,12 @@ def _determine_current_version(defaults, vcs_info):
         defaults["current_version"] = vcs_info["current_version"]
 
 
-def _determine_config_file(known_args):
-    explicit_config = hasattr(known_args, "config_file")
+def _determine_config_file(explicit_config):
     if explicit_config:
-        config_file = known_args.config_file
-    elif not os.path.exists(".bumpversion.cfg") and os.path.exists("setup.cfg"):
-        config_file = "setup.cfg"
-    else:
-        config_file = ".bumpversion.cfg"
-    return config_file, explicit_config
+        return explicit_config
+    if not os.path.exists(".bumpversion.cfg") and os.path.exists("setup.cfg"):
+        return "setup.cfg"
+    return ".bumpversion.cfg"
 
 
 def _load_configuration(config_file, defaults, explicit_config, files, part_configs):

--- a/bumpversion/cli.py
+++ b/bumpversion/cli.py
@@ -240,23 +240,6 @@ def main(original_args=None):
         vcs.tag(sign_tags, tag_name, tag_message)
 
 
-def _assemble_new_version(context, current_version, defaults, known_args, new_version, positionals, vc):
-    if "new_version" not in defaults and known_args.current_version:
-        try:
-            if current_version and len(positionals) > 0:
-                logger.info("Attempting to increment part '{}'".format(positionals[0]))
-                new_version = current_version.bump(positionals[0], vc.order())
-                logger.info("Values are now: " + keyvaluestring(new_version._values))
-                defaults["new_version"] = vc.serialize(new_version, context)
-        except MissingValueForSerializationException as e:
-            logger.info("Opportunistic finding of new_version failed: " + e.message)
-        except IncompleteVersionRepresentationException as e:
-            logger.info("Opportunistic finding of new_version failed: " + e.message)
-        except KeyError as e:
-            logger.info("Opportunistic finding of new_version failed")
-    return new_version
-
-
 def _parse_phase_1(original_args):
     positionals, args = split_args_in_optional_and_positional(
         sys.argv[1:] if original_args is None else original_args
@@ -543,6 +526,23 @@ def _assemble_context(vcs_info):
         + list(vcs_info.items())
     )
     return context
+
+
+def _assemble_new_version(context, current_version, defaults, known_args, new_version, positionals, vc):
+    if "new_version" not in defaults and known_args.current_version:
+        try:
+            if current_version and len(positionals) > 0:
+                logger.info("Attempting to increment part '{}'".format(positionals[0]))
+                new_version = current_version.bump(positionals[0], vc.order())
+                logger.info("Values are now: " + keyvaluestring(new_version._values))
+                defaults["new_version"] = vc.serialize(new_version, context)
+        except MissingValueForSerializationException as e:
+            logger.info("Opportunistic finding of new_version failed: " + e.message)
+        except IncompleteVersionRepresentationException as e:
+            logger.info("Opportunistic finding of new_version failed: " + e.message)
+        except KeyError as e:
+            logger.info("Opportunistic finding of new_version failed")
+    return new_version
 
 
 def _parse_phase_3(args, defaults, parser2, positionals, remaining_argv):

--- a/bumpversion/cli.py
+++ b/bumpversion/cli.py
@@ -585,18 +585,6 @@ def main(original_args=None):
         vcs.tag(sign_tags, tag_name, tag_message)
 
 
-def _determine_current_version(defaults, vcs_info):
-    if "current_version" in vcs_info:
-        defaults["current_version"] = vcs_info["current_version"]
-
-
-def _determine_vcs_is_usable(vcs_info):
-    for vcs in VCS:
-        if vcs.is_usable():
-            vcs_info.update(vcs.latest_tag_info())
-    return vcs
-
-
 def _parse_phase_1(original_args):
     positionals, args = split_args_in_optional_and_positional(
         sys.argv[1:] if original_args is None else original_args
@@ -654,3 +642,15 @@ def _setup_logging(known_args):
     root_logger = logging.getLogger('')
     root_logger.setLevel(log_level)
     logger.debug("Starting {}".format(DESCRIPTION))
+
+
+def _determine_vcs_is_usable(vcs_info):
+    for vcs in VCS:
+        if vcs.is_usable():
+            vcs_info.update(vcs.latest_tag_info())
+    return vcs
+
+
+def _determine_current_version(defaults, vcs_info):
+    if "current_version" in vcs_info:
+        defaults["current_version"] = vcs_info["current_version"]

--- a/bumpversion/cli.py
+++ b/bumpversion/cli.py
@@ -108,11 +108,7 @@ def main(original_args=None):
     context = _assemble_context(vcs_info)
     new_version = _assemble_new_version(context, current_version, defaults, known_args, new_version, positionals, vc)
     args, file_names = _parse_phase_3(args, defaults, parser2, positionals, remaining_argv)
-
-    if args.new_version:
-        new_version = vc.parse(args.new_version)
-
-    logger.info("New version will be '%s'", args.new_version)
+    new_version = _parse_new_version(args, new_version, vc)
 
     file_names = file_names or positionals[1:]
 
@@ -664,3 +660,10 @@ def _parse_phase_3(args, defaults, parser2, positionals, remaining_argv):
         logger.info("Dry run active, won't touch any files.")
 
     return args, file_names
+
+
+def _parse_new_version(args, new_version, vc):
+    if args.new_version:
+        new_version = vc.parse(args.new_version)
+    logger.info("New version will be '{}'".format(args.new_version))
+    return new_version

--- a/bumpversion/cli.py
+++ b/bumpversion/cli.py
@@ -97,15 +97,7 @@ def main(original_args=None):
     _setup_logging(known_args)
     vcs = _determine_vcs_is_usable(vcs_info)
     _determine_current_version(defaults, vcs_info)
-
-    explicit_config = hasattr(known_args, "config_file")
-
-    if explicit_config:
-        config_file = known_args.config_file
-    elif not os.path.exists(".bumpversion.cfg") and os.path.exists("setup.cfg"):
-        config_file = "setup.cfg"
-    else:
-        config_file = ".bumpversion.cfg"
+    config_file, explicit_config = _determine_config_file(known_args)
 
     # setup.cfg supports interpolation - for compatibility we must do the same.
     if os.path.basename(config_file) == "setup.cfg":
@@ -654,3 +646,14 @@ def _determine_vcs_is_usable(vcs_info):
 def _determine_current_version(defaults, vcs_info):
     if "current_version" in vcs_info:
         defaults["current_version"] = vcs_info["current_version"]
+
+
+def _determine_config_file(known_args):
+    explicit_config = hasattr(known_args, "config_file")
+    if explicit_config:
+        config_file = known_args.config_file
+    elif not os.path.exists(".bumpversion.cfg") and os.path.exists("setup.cfg"):
+        config_file = "setup.cfg"
+    else:
+        config_file = ".bumpversion.cfg"
+    return config_file, explicit_config

--- a/bumpversion/cli.py
+++ b/bumpversion/cli.py
@@ -94,6 +94,7 @@ def main(original_args=None):
     vcs_info = {}
     part_configs = {}
     files = []
+    new_version = None
 
     args, known_args, root_parser, positionals = _parse_phase_1(original_args)
     _setup_logging(known_args)
@@ -104,14 +105,7 @@ def main(original_args=None):
     known_args, parser2, remaining_argv = _parse_phase_2(args, defaults, known_args, root_parser)
     vc = _setup_versionconfig(known_args, part_configs)
     current_version = _update_current_version(known_args, vc)
-
-    new_version = None
-
-    context = dict(
-        list(time_context.items())
-        + list(prefixed_environ().items())
-        + list(vcs_info.items())
-    )
+    context = _assemble_context(vcs_info)
 
     if "new_version" not in defaults and known_args.current_version:
         try:
@@ -665,3 +659,12 @@ def _update_current_version(known_args, vc):
         vc.parse(known_args.current_version) if known_args.current_version else None
     )
     return current_version
+
+
+def _assemble_context(vcs_info):
+    context = dict(
+        list(time_context.items())
+        + list(prefixed_environ().items())
+        + list(vcs_info.items())
+    )
+    return context

--- a/bumpversion/cli.py
+++ b/bumpversion/cli.py
@@ -118,7 +118,6 @@ def main(original_args=None):
     _replace_version_in_files(files, current_version, new_version, args.dry_run, context)
     _log_list(config, args.new_version)
     _update_config_file(config, config_file, config_file_exists, args.new_version, args.dry_run)
-
     if vcs:
         vcs_context = _commit_to_vcs(args, config_file, config_file_exists, files, vcs)
         _tag_in_vcs(args, vcs, vcs_context)
@@ -595,11 +594,11 @@ def _log_list(config, new_version):
     config.remove_option("bumpversion", "new_version")
 
 
-def _update_config_file(args, config, config_file, config_file_exists):
-    config.set("bumpversion", "current_version", args.new_version)
+def _update_config_file(config, config_file, config_file_exists, new_version, dry_run):
+    config.set("bumpversion", "current_version", new_version)
     new_config = StringIO()
     try:
-        write_to_config_file = (not args.dry_run) and config_file_exists
+        write_to_config_file = (not dry_run) and config_file_exists
 
         logger.info(
             "{} to config file {}:".format(

--- a/bumpversion/cli.py
+++ b/bumpversion/cli.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 import argparse
 from datetime import datetime
 import io
+import itertools
 import logging
 import os
 import re
@@ -407,10 +408,9 @@ def _parse_current_version(current_version, vc):
 
 def _assemble_context(vcs_info):
     context = dict(
-        list(time_context.items())
-        + list(prefixed_environ().items())
-        + list(vcs_info.items())
+        itertools.chain(time_context.items(), prefixed_environ().items(), vcs_info.items())
     )
+
     return context
 
 

--- a/bumpversion/cli.py
+++ b/bumpversion/cli.py
@@ -103,10 +103,7 @@ def main(original_args=None):
     config, config_file_exists = _load_configuration(config_file, defaults, explicit_config, files, part_configs)
     known_args, parser2, remaining_argv = _parse_phase_2(args, defaults, known_args, root_parser)
     vc = _setup_versionconfig(known_args, part_configs)
-
-    current_version = (
-        vc.parse(known_args.current_version) if known_args.current_version else None
-    )
+    current_version = _update_current_version(known_args, vc)
 
     new_version = None
 
@@ -661,3 +658,10 @@ def _setup_versionconfig(known_args, part_configs):
         # TODO: use re.error here mayhaps, also: should we log?
         sys.exit(1)
     return vc
+
+
+def _update_current_version(known_args, vc):
+    current_version = (
+        vc.parse(known_args.current_version) if known_args.current_version else None
+    )
+    return current_version

--- a/bumpversion/version_part.py
+++ b/bumpversion/version_part.py
@@ -162,6 +162,8 @@ class VersionConfig(object):
         return labels_for_format(self.serialize_formats[0])
 
     def parse(self, version_string):
+        if not version_string:
+            return None
 
         regexp_one_line = "".join(
             [l.split("#")[0].strip() for l in self.parse_regex.pattern.splitlines()]


### PR DESCRIPTION
This does not change any functionality, but it makes main() much shorter and at least
helps to decode what's going on.

Done as a preparation for implementing #57, which has impact on argument parsing.

I've made sure that `cli.py` satisfies `pylint` similar to what's done in #67.
Merging this with `#67` would give merge conflicts, but this way it does not require manual resolution.