### PR TITLE
Propagate current_version and new_version to commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,15 @@ General configuration is grouped in a `[bumpversion]` section.
 
   Also available as `(--commit | --no-commit)`.
 
+  In many projects it is common to have a pre-commit hook that runs prior to a
+  commit and in case of failure aborts the commit. For some use cases it might
+  be desired that when bumping a version and having `commit = True`, the
+  pre-commit hook should perform slightly different actions than in regular
+  commits. For example run an extended set of checks only for actual releases of
+  the software. To allow the pre-commit hooks to distinguish a bumpversion
+  commit, the `BUMPVERSION_CURRENT_VERSION` and `BUMPVERSION_NEW_VERSION`
+  environment variables are set when executing the commit command.
+
 #### `message =`
   _**[optional]**_<br />
   **default:** `Bump version: {current_version} → {new_version}`

--- a/bumpversion/cli.py
+++ b/bumpversion/cli.py
@@ -662,7 +662,7 @@ def _commit_to_vcs(files, context, config_file, config_file_exists, vcs, args):
         commit_message,
     )
     if do_commit:
-        vcs.commit(message=commit_message)
+        vcs.commit(message=commit_message, context=context)
     return context
 
 

--- a/bumpversion/vcs.py
+++ b/bumpversion/vcs.py
@@ -30,7 +30,7 @@ class BaseVCS(object):
         env = os.environ.copy()
         env[str("HGENCODING")] = str("utf-8")
         for key in ["current_version", "new_version"]:
-            env[str("BUMPVERSION_"+key.upper())] = context[key]
+            env[str("BUMPVERSION_"+key.upper())] = str(context[key])
         try:
             subprocess.check_output(cls._COMMIT_COMMAND + [f.name], env=env)
         except subprocess.CalledProcessError as exc:

--- a/bumpversion/vcs.py
+++ b/bumpversion/vcs.py
@@ -10,7 +10,7 @@ from tempfile import NamedTemporaryFile
 
 from bumpversion.exceptions import (
     WorkingDirectoryIsDirtyException,
-    MercurialDoesNotSupportSignedTagsException
+    MercurialDoesNotSupportSignedTagsException,
 )
 from bumpversion.compat import _command_args
 
@@ -29,8 +29,8 @@ class BaseVCS(object):
             f.write(message.encode("utf-8"))
         env = os.environ.copy()
         env[str("HGENCODING")] = str("utf-8")
-        for key in ["current_version", "new_version"]:
-            env[str("BUMPVERSION_"+key.upper())] = str(context[key])
+        for key in ("current_version", "new_version"):
+            env[str("BUMPVERSION_" + key.upper())] = str(context[key])
         try:
             subprocess.check_output(cls._COMMIT_COMMAND + [f.name], env=env)
         except subprocess.CalledProcessError as exc:

--- a/bumpversion/vcs.py
+++ b/bumpversion/vcs.py
@@ -29,8 +29,8 @@ class BaseVCS(object):
             f.write(message.encode("utf-8"))
         env = os.environ.copy()
         env[str("HGENCODING")] = str("utf-8")
-        for key in ['current_version', 'new_version']:
-            env['BUMPVERSION_'+key.upper()] = context[key]
+        for key in ["current_version", "new_version"]:
+            env[str("BUMPVERSION_"+key.upper())] = context[key]
         try:
             subprocess.check_output(cls._COMMIT_COMMAND + [f.name], env=env)
         except subprocess.CalledProcessError as exc:

--- a/bumpversion/vcs.py
+++ b/bumpversion/vcs.py
@@ -24,11 +24,13 @@ class BaseVCS(object):
     _COMMIT_COMMAND = None
 
     @classmethod
-    def commit(cls, message):
+    def commit(cls, message, context):
         with NamedTemporaryFile("wb", delete=False) as f:
             f.write(message.encode("utf-8"))
         env = os.environ.copy()
         env[str("HGENCODING")] = str("utf-8")
+        for key in ['current_version', 'new_version']:
+            env['BUMPVERSION_'+key.upper()] = context[key]
         try:
             subprocess.check_output(cls._COMMIT_COMMAND + [f.name], env=env)
         except subprocess.CalledProcessError as exc:


### PR DESCRIPTION
Propagate current_version and new_version to commit as environment variables so that pre-commit hooks can distinguish between normal commits and bumpversion commits.