### PR TITLE
Fix AppVeyor builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,6 +29,7 @@ init:
   - ps: "ls C:/Python*"
 
 install:
+  - "%PYTHON%/python.exe -m pip install --upgrade wheel pip setuptools virtualenv"
   - "%PYTHON%/python.exe -m pip install tox"
   - "%PYTHON%/python.exe -m pip install -e ."
 


### PR DESCRIPTION
The recent AppVeyor breakage was caused by outdated versions of python packaging modules (wheel, pip, setuptools, virtualenv).

Tox used to hide these issues because it depended on more recent versions of these modules.
Since version 3.10, Tox no longer does this so we have to upgrade them ourselves.