### PR TITLE
Enhance missing VCS command detection (errno 13)

### DIFF
--- a/bumpversion/vcs.py
+++ b/bumpversion/vcs.py
@@ -2,10 +2,10 @@
 
 from __future__ import unicode_literals, print_function
 
+import errno
 import logging
 import os
 import subprocess
-import errno
 from tempfile import NamedTemporaryFile
 
 from bumpversion.exceptions import (

--- a/bumpversion/vcs.py
+++ b/bumpversion/vcs.py
@@ -51,8 +51,8 @@ class BaseVCS(object):
                 == 0
             )
         except OSError as e:
-            if e.errno == 2:
-                # mercurial is not installed then, ok.
+            if e.errno in (2, 13):
+                # VCS is not installed or permission denied then, ok.
                 return False
             raise
 

--- a/bumpversion/vcs.py
+++ b/bumpversion/vcs.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals, print_function
 import logging
 import os
 import subprocess
+import errno
 from tempfile import NamedTemporaryFile
 
 from bumpversion.exceptions import (
@@ -51,8 +52,7 @@ class BaseVCS(object):
                 == 0
             )
         except OSError as e:
-            if e.errno in (2, 13):
-                # VCS is not installed or permission denied then, ok.
+            if e.errno in (errno.ENOENT, errno.EACCES):
                 return False
             raise
 


### PR DESCRIPTION
On some Linux platforms (possibly due to an LSM such as SELinux or AppArmor) instead of just getting error 2 (File not found) the OS returns error 13 (Permission Denied).   This patch treats errorno 2 and 13 the same.  Simply put, the VCS is not available and therefore should not be considered.

Without this fix, on some Linux machines, running `bumpversion` or `bumpversion --help` results in:

    OSError: [Error 13] Permission denied
