### PR TITLE
Support metadata.version in setup.cfg

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1976,6 +1976,26 @@ def test_correct_interpolation_for_setup_cfg_files(tmpdir, configfile):
     assert "current_version = 1.0.0" in tmpdir.join(configfile).read()
 
 
+def test_setup_cfg_metadata_version(tmpdir):
+    """
+    If a setup.cfg file is used and a metadata.version is present,
+    prefer that as if it were the bumpversion.current_version.
+    """
+    tmpdir.join("setup.cfg").write("""[metadata]
+version=0.0.13
+""")
+
+    tmpdir.chdir()
+    main(['patch', '--verbose'])
+
+    assert """[bumpversion]
+
+[metadata]
+version = 0.0.14
+
+""" == tmpdir.join("setup.cfg").read()
+
+
 @pytest.mark.parametrize("newline", [b'\n', b'\r\n'])
 def test_retain_newline(tmpdir, configfile, newline):
     tmpdir.join("file.py").write_binary(dedent("""


### PR DESCRIPTION
As proposed in #62, this change allows `metadata.version` in a setup.cfg file to stand in for `bumpversion.current_version`, meaning that with this change, `bump2version` would work with zero config on a project using setuptools' declarative config with static version numbers.

Although this technique worked, it feels a bit hacky, wrapping the configparser object and tricking the bumpversion code into thinking it's reading and writing the config value into the usual place(s).

I'm also not happy that it introduces an empty `bumpversion` section into the `setup.cfg` file when no section is needed. I'm out of time for now, so I want to get this published for review/comment. I look forward to your feedback.