### PR TITLE
No rewrite config file when bumping

### DIFF
--- a/bumpversion/cli.py
+++ b/bumpversion/cli.py
@@ -113,9 +113,9 @@ def main(original_args=None):
     _log_list(config, args.new_version)
 
     # store the new version
-    # _update_config_file(
-    #     config, config_file, config_newlines, config_file_exists, args.new_version, args.dry_run,
-    # )
+    _update_config_file(
+        config, config_file, config_newlines, config_file_exists, args.new_version, args.dry_run,
+    )
 
     # commit and tag
     if vcs:
@@ -610,7 +610,7 @@ def _update_config_file(
     config.set("bumpversion", "current_version", new_version)
     new_config = StringIO()
     try:
-        write_to_config_file = (not dry_run) and config_file_exists
+        write_to_config_file = (not dry_run) and not config_file_exists
 
         logger.info(
             "%s to config file %s:",

--- a/bumpversion/cli.py
+++ b/bumpversion/cli.py
@@ -104,14 +104,18 @@ def main(original_args=None):
         for file_name
         in (file_names or positionals[1:])
     )
+
+    if config_file_exists and config_file not in files:
+        files.extend([ConfiguredFile(config_file, version_config)])
+
     _check_files_contain_version(files, current_version, context)
     _replace_version_in_files(files, current_version, new_version, args.dry_run, context)
     _log_list(config, args.new_version)
 
     # store the new version
-    _update_config_file(
-        config, config_file, config_newlines, config_file_exists, args.new_version, args.dry_run,
-    )
+    # _update_config_file(
+    #     config, config_file, config_newlines, config_file_exists, args.new_version, args.dry_run,
+    # )
 
     # commit and tag
     if vcs:


### PR DESCRIPTION
I find a bit annoying that when you bumpversion the format of the configuration file changes because it's completely rewritten. This was mostly ok with a `.bumpversion` file, but now that I have moved the bumpversion configuration to `setup.cfg` it's worse. For example, I like to keep sections for different services separated by two empty lines, which are reduced to one when I bumpversion. This also affects #87.

I wonder if it's at all necessary to rewrite the whole config file every time you bump. It seems the only thing it changes in the file is that you bump the version of `current_version`, so the same thing could be achieved by treating the config file as any other file to bump.

I've implemented this here and seems to work, but I don't understand the internals of bump2version very well and I may be missing some important subtlety.