### PR TITLE
Fix bug in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ values =
 ```ini
 [bumpversion]
 current_version = 1.alpha
-parse = (?P<num>\d+)\.(?P<release>.*)
+parse = (?P<num>\d+)(\.(?P<release>.*))?
 serialize =
   {num}.{release}
   {num}


### PR DESCRIPTION
In the `optional_value` section of the README, the example given crashes after the second run of `bump2version release`.

The example says:
> ```ini
> [bumpversion]
> current_version = 1.alpha
> parse = (?P<num>\d+)\.(?P<release>.*)
> serialize =
>   {num}.{release}
>   {num}
> 
> [bumpversion:part:release]
> optional_value = gamma
> values =
>   alpha
>   beta
>   gamma
> ```
> Here, `bump2version release` would bump `1.alpha` to `1.beta`. Executing `bump2version release` again would bump `1.beta` to `1`, because `release` being `gamma` is configured optional.

Running `bump2version release` crashes when `current_version = 1.beta` because the `parse` regex does not handle version strings such as `1`.

```
Evaluating 'parse' option: '(?P<num>\d+)\.(?P<release>.*)' does not parse current version '1'
Traceback (most recent call last):
  File "/Users/guillaumelostis/.venv/bump/bin/bump2version", line 11, in <module>
    load_entry_point('bump2version', 'console_scripts', 'bump2version')()
  File "/Users/guillaumelostis/code/bump2version/bumpversion/cli.py", line 118, in main
    context = _commit_to_vcs(files, context, config_file, config_file_exists, vcs, args, current_version, new_version)
  File "/Users/guillaumelostis/code/bump2version/bumpversion/cli.py", line 662, in _commit_to_vcs
    context.update({'new_' + part: new_version[part].value for part in new_version})
TypeError: 'NoneType' object is not iterable
```

In order to handle both `1.beta` and `1` versions, the `.` between `num` and `release` needs to be made optional.