### PR TITLE
Fix the VCS support detection in test markers

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -32,16 +32,17 @@ def _get_subprocess_env():
 
 
 SUBPROCESS_ENV = _get_subprocess_env()
+call = partial(subprocess.call, env=SUBPROCESS_ENV, shell=True)
 check_call = partial(subprocess.check_call, env=SUBPROCESS_ENV)
 check_output = partial(subprocess.check_output,  env=SUBPROCESS_ENV)
 
 xfail_if_no_git = pytest.mark.xfail(
-  subprocess.call(["git", "version"]) != 0,
+  call(["git version"]) != 0,
   reason="git is not installed"
 )
 
 xfail_if_no_hg = pytest.mark.xfail(
-  subprocess.call(["hg", "version"]) != 0,
+  call(["hg version"]) != 0,
   reason="hg is not installed"
 )
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -37,12 +37,12 @@ check_call = partial(subprocess.check_call, env=SUBPROCESS_ENV)
 check_output = partial(subprocess.check_output,  env=SUBPROCESS_ENV)
 
 xfail_if_no_git = pytest.mark.xfail(
-  call(["git version"]) != 0,
+  call("git version") != 0,
   reason="git is not installed"
 )
 
 xfail_if_no_hg = pytest.mark.xfail(
-  call(["hg version"]) != 0,
+  call("hg version") != 0,
   reason="hg is not installed"
 )
 


### PR DESCRIPTION
I believe these changes should help close https://github.com/c4urself/bump2version/issues/96.

Reverting a change that accidentally introduced a regression in https://github.com/c4urself/bump2version/pull/46/commits/cfb197095def2409bfee7da09b16983119dfcc9c

See the linked issue for the full details.