### PR TITLE
Allow a "(suffix)" to the 'file' section (support processing a file multiple times)

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,11 @@ values =
 
 This configuration is in the section: `[bumpversion:file:…]`
 
+Note: The configuration file format requires each section header to be
+unique. If you want to process a certain file multiple times,
+you may append a description between parens to the `file` keyword:
+`[bumpversion:file (special one):…]`.
+
 #### `parse =`
   **default:** `(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)`
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -64,6 +64,17 @@ def configfile(request):
     return request.param
 
 
+@pytest.fixture(params=[
+    "file",
+    "file(suffix)",
+    "file (suffix with space)",
+    "file (suffix lacking closing paren",
+])
+def file_keyword(request):
+    """Return multiple possible styles for the bumpversion:file keyword."""
+    return request.param
+
+
 try:
     RawConfigParser(empty_lines_in_values=False)
     using_old_configparser = False
@@ -281,6 +292,22 @@ new_version: 0.10.3
     assert "0.10.3" == tmpdir.join("file2").read()
 
 
+def test_file_keyword_with_suffix_is_accepted(tmpdir, configfile, file_keyword):
+    tmpdir.join("file2").write("0.10.2")
+    tmpdir.join(configfile).write(
+        """[bumpversion]
+    current_version: 0.10.2
+    new_version: 0.10.3
+    [bumpversion:%s:file2]
+    """ % file_keyword
+    )
+
+    tmpdir.chdir()
+    main(['patch'])
+
+    assert "0.10.3" == tmpdir.join("file2").read()
+
+
 def test_multiple_config_files(tmpdir):
     tmpdir.join("file2").write("0.10.2")
     tmpdir.join("setup.cfg").write("""[bumpversion]
@@ -296,6 +323,39 @@ new_version: 0.10.4
     main(['patch'])
 
     assert "0.10.4" == tmpdir.join("file2").read()
+
+
+def test_single_file_processed_twice(tmpdir):
+    """
+    Verify that a single file "file2" can be processed twice.
+
+    Use two file_ entries, both with a different suffix after
+    the underscore.
+    Employ different parse/serialize and search/replace configs
+    to verify correct interpretation.
+    """
+    tmpdir.join("file2").write("dots: 0.10.2\ndashes: 0-10-2")
+    tmpdir.join("setup.cfg").write("""[bumpversion]
+current_version: 0.10.2
+new_version: 0.10.3
+[bumpversion:file:file2]""")
+    tmpdir.join(".bumpversion.cfg").write("""[bumpversion]
+current_version: 0.10.2
+new_version: 0.10.4
+[bumpversion:file (version with dots):file2]
+search = dots: {current_version}
+replace = dots: {new_version}
+[bumpversion:file (version with dashes):file2]
+search = dashes: {current_version}
+replace = dashes: {new_version}
+parse = (?P<major>\d+)-(?P<minor>\d+)-(?P<patch>\d+)
+serialize = {major}-{minor}-{patch}
+""")
+
+    tmpdir.chdir()
+    main(['patch'])
+
+    assert "dots: 0.10.4\ndashes: 0-10-4" == tmpdir.join("file2").read()
 
 
 def test_config_file_is_updated(tmpdir):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -339,7 +339,7 @@ def test_single_file_processed_twice(tmpdir):
 current_version: 0.10.2
 new_version: 0.10.3
 [bumpversion:file:file2]""")
-    tmpdir.join(".bumpversion.cfg").write("""[bumpversion]
+    tmpdir.join(".bumpversion.cfg").write(r"""[bumpversion]
 current_version: 0.10.2
 new_version: 0.10.4
 [bumpversion:file (version with dots):file2]


### PR DESCRIPTION
Fixes #111

Instead of adding another colon, simply allow the `file` part of the section header to be extended
with a suffix (starting with an underscore).

I think this is pretty elegant, even though it's still a hack around the INI parser limitation.

    [bumpversion:file_myfile_first_pass:version.txt]
    [bumpversion:file_myfile_second_pass:version.txt]

This *does* mean that in the future we can not use any other `file_` section headers.  E.g. if we would add support for `glob`, we can not call it `file_glob` because *some* user might be using that in a config file already.

Update: the syntax has now changed to parens instead of an underscore:

    [bumpversion:file(myfile first pass):version.txt]
    [bumpversion:file(myfile second pass):version.txt]
