### PR TITLE
Mention similar / related tools in a separate Markdown document

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 This is an interim fork of the excellent project that can be found here: https://github.com/peritus/bumpversion
 
 In the future, both projects will re-merge with backwards
-compatibility as a goal.
+compatibility as a goal (issue [86](https://github.com/c4urself/bump2version/issues/86)).
 
 ## Overview
 

--- a/README.md
+++ b/README.md
@@ -10,10 +10,8 @@
 
 This is an interim fork of the excellent project that can be found here: https://github.com/peritus/bumpversion
 
-Unfortunately it seems like development has been stuck for some time and no activity has been seen from the
-author, to that end this project is a drop-in replacement that merges in some of the more important fixes.
-
-Hopefully we can merge back into the original bumpversion and carry on development there.
+In the future, both projects will re-merge with backwards
+compatibility as a goal.
 
 ## Overview
 

--- a/README.md
+++ b/README.md
@@ -33,12 +33,17 @@ If you want to use Python 2, use `pip>=9` and you'll get the last supported vers
 or pin `bump2version<1`.
 
 
-
 <!---
 ## Screencast
 
 <a href="https://asciinema.org/a/3828">Watch a screencast here</a>.
 -->
+
+## Alternatives
+
+If bump2version does not fully suit your needs, you could take a look
+at other tools doing similar or related tasks:
+[ALTERNATIVES.md](https://github.com/c4urself/bump2version/blob/master/RELATED.md).
 
 ## Installation
 

--- a/RELATED.md
+++ b/RELATED.md
@@ -1,0 +1,31 @@
+# Similar or related tools
+
+* [bumpversion](https://pypi.org/project/bumpversion/) is the original project
+  off of which `bump2version` was forked.  We'll be merging
+  back with them at some point.
+
+* [ADVbumpversion](https://github.com/andrivet/advbumpversion) is another fork.
+  It offers some features which are still work in progress here; it's
+  definitely our desire to merge back.
+
+* [zest.releaser](https://pypi.org/project/zest.releaser/) manages
+  your Python package releases and keeps the version number in one location.
+
+* [setuptools-scm](https://pypi.org/project/setuptools-scm/) relies on 
+  version control tags and the state of your working copy to determine
+  the version number.
+
+* [incremental](https://pypi.org/project/incremental/) integrates into
+  setuptools and maintains the version number in `_version.py`.
+
+* Invocations [packaging.release](https://invocations.readthedocs.io/en/latest/)
+  are a set of tasks for [invoke](https://www.pyinvoke.org/).
+  These assume your version is in `_version.py` and you're using
+  semantic versioning.
+
+* [python-semantic.release](https://github.com/relekang/python-semantic-release)
+  automatically bumps your (semantic) version number based on the 
+  types of commits (breaking/new/bugfix) in your source control.
+  
+* [towncrier](https://pypi.org/project/towncrier/) assembles a changelog
+  file from multiple snippets found in individual (merge) commits.

--- a/RELATED.md
+++ b/RELATED.md
@@ -27,5 +27,14 @@
   automatically bumps your (semantic) version number based on the 
   types of commits (breaking/new/bugfix) in your source control.
   
+  
+## Change log building
+  
 * [towncrier](https://pypi.org/project/towncrier/) assembles a changelog
   file from multiple snippets found in individual (merge) commits.
+  
+* [releases](https://pypi.org/project/releases/) helps build a Sphinx
+  ReStructuredText changelog.
+  
+* [gitchangelog](https://pypi.org/project/gitchangelog/) searches
+  the git commit history to make a configurable changelog file.

--- a/RELATED.md
+++ b/RELATED.md
@@ -2,11 +2,11 @@
 
 * [bumpversion](https://pypi.org/project/bumpversion/) is the original project
   off of which `bump2version` was forked.  We'll be merging
-  back with them at some point.
+  back with them at some point (issue [#86](https://github.com/c4urself/bump2version/issues/86)).
 
 * [ADVbumpversion](https://github.com/andrivet/advbumpversion) is another fork.
   It offers some features which are still work in progress here; it's
-  definitely our desire to merge back.
+  definitely our desire to merge back (issue [#121](https://github.com/c4urself/bump2version/issues/121)).
 
 * [zest.releaser](https://pypi.org/project/zest.releaser/) manages
   your Python package releases and keeps the version number in one location.


### PR DESCRIPTION
I think it would beneficial to help users determine if they're actually looking at the right tool for the job.

Fixes #118