### PR TITLE
Add parameter to search & replace strictly

### DIFF
--- a/bumpversion/cli.py
+++ b/bumpversion/cli.py
@@ -337,6 +337,11 @@ def _load_configuration(config_file, explicit_config, defaults):
                     "search", "{current_version}"
                 )
 
+            if "search_strict" not in section_config:
+                section_config["search_strict"] = defaults.get(
+                    "search_strict", False
+                )
+
             if "replace" not in section_config:
                 section_config["replace"] = defaults.get("replace", "{new_version}")
 
@@ -378,6 +383,13 @@ def _parse_arguments_phase_2(args, known_args, defaults, root_parser):
         default=defaults.get("search", "{current_version}"),
     )
     parser2.add_argument(
+        "--search-strict",
+        action="store_true",
+        default=defaults.get("search_strict", False),
+        help="Search strictly for the given strings - no fallback to the original version",
+        required=False,
+    )
+    parser2.add_argument(
         "--replace",
         metavar="REPLACE",
         help="Template for complete string to replace",
@@ -398,6 +410,7 @@ def _setup_versionconfig(known_args, part_configs):
             parse=known_args.parse,
             serialize=known_args.serialize,
             search=known_args.search,
+            search_strict=known_args.search_strict,
             replace=known_args.replace,
             part_configs=part_configs,
         )

--- a/bumpversion/utils.py
+++ b/bumpversion/utils.py
@@ -116,8 +116,10 @@ class ConfiguredFile:
 
         file_content_after = file_content_before.replace(search_for, replace_with)
 
-        if file_content_before == file_content_after:
-            # TODO expose this to be configurable
+        if not self._versionconfig.search_strict and file_content_before == file_content_after:
+            logger.debug("The pattern '%s' was not found for file %s. Trying to search with the original version '%s'.",
+                search_for, self.path, current_version.original
+            )
             file_content_after = file_content_before.replace(
                 current_version.original, replace_with
             )

--- a/bumpversion/version_part.py
+++ b/bumpversion/version_part.py
@@ -133,7 +133,7 @@ class VersionConfig:
     Holds a complete representation of a version string
     """
 
-    def __init__(self, parse, serialize, search, replace, part_configs=None):
+    def __init__(self, parse, serialize, search, search_strict, replace, part_configs=None):
 
         try:
             self.parse_regex = re.compile(parse, re.VERBOSE)
@@ -149,6 +149,7 @@ class VersionConfig:
 
         self.part_configs = part_configs
         self.search = search
+        self.search_strict = search_strict
         self.replace = replace
 
 


### PR DESCRIPTION
The current behavior of search and replace is:

> If the pattern of search isn't found, try to search for the default version representation (not the pattern).

This may lead to unwanted or strange replacements. As I debugged such unwanted replacements I found a [TODO](https://github.com/c4urself/bump2version/blob/648036b51b68b2383ff9e236ab6e785be39aa0b1/bumpversion/utils.py#L120) in your code and decided to implement it. The new behavior (with the option enabled) will be:

> If the pattern of search isn't found, there will be an error. The error will be the same error as usual if the version isn't found at all.

The implementation is opt-in and should not alter the current behavior of the program at all. If you don't specify the new option, everything will work as it did before. 

I suggest bringing this into Version 1.1.0 if you follow semver.