### PR TITLE
Allow using special char

### DIFF
--- a/bumpversion/cli.py
+++ b/bumpversion/cli.py
@@ -56,6 +56,7 @@ RE_DETECT_SECTION_TYPE = re.compile(
 logger_list = logging.getLogger("bumpversion.list")
 logger = logging.getLogger(__name__)
 time_context = {"now": datetime.now(), "utcnow": datetime.utcnow()}
+special_char_context = {c: c for c in ("#", ";")}
 
 
 OPTIONAL_ARGUMENTS_THAT_TAKE_VALUES = [
@@ -93,7 +94,12 @@ def main(original_args=None):
     version_config = _setup_versionconfig(known_args, part_configs)
     current_version = version_config.parse(known_args.current_version)
     context = dict(
-        itertools.chain(time_context.items(), prefixed_environ().items(), vcs_info.items())
+        itertools.chain(
+            time_context.items(),
+            prefixed_environ().items(),
+            vcs_info.items(),
+            special_char_context.items(),
+        )
     )
 
     # calculate the desired new version
@@ -666,6 +672,7 @@ def _commit_to_vcs(files, context, config_file, config_file_exists, vcs, args,
     context.update(prefixed_environ())
     context.update({'current_' + part: current_version[part].value for part in current_version})
     context.update({'new_' + part: new_version[part].value for part in new_version})
+    context.update(special_char_context)
 
     commit_message = args.message.format(**context)
 


### PR DESCRIPTION
I was trying to write a `replace` for a changelog in the follow format.

```markdown
    # https://keepachangelog.com/en/1.0.0/

    ## [Unreleased]
    ### Added
    - Foobar

    ## [0.0.1] - 2014-05-31
    ### Added
    - This CHANGELOG file to hopefully serve as an evolving example of a
      standardized open source project CHANGELOG.
    """))
```

but later I found the `#` is [treated as the default comment prefix by the ConfigParser](https://docs.python.org/3/library/configparser.html#configparser.ConfigParser).

This PR is trying to workaround the issue by substituting the `#` using `{#}`. Please check the test case for details.

```diff
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 # https://keepachangelog.com/en/1.0.0/

 ## [Unreleased]
+
+## [1.6.0] - 2019-03-19
 ### Added
 - Foobar
```