### PR TITLE
Actually format version parts

### DIFF
--- a/bumpversion/version_part.py
+++ b/bumpversion/version_part.py
@@ -69,7 +69,39 @@ class VersionPart:
         return self.value == self.config.optional_value
 
     def __format__(self, format_spec):
-        return self.value
+        formatted = None
+        template = '{value:{format_spec}}'
+        error = None
+
+        for target_type in [str, int]:
+            # Try to format the val as a string and an int
+            # This should cover most, if not all, bases of format specs
+            try:
+                coerced_val = target_type(self.value)
+                formatted = template.format(
+                    value=coerced_val,
+                    format_spec=format_spec,
+                )
+            except Exception as e:
+                logger.debug(
+                    'Unable to parse format: {}'.format(e)
+                )
+                error = e
+
+            if formatted is not None:
+                break
+
+        if formatted is None:
+            logger.warning(
+                'Defaulting to unformated {value}. Formatting with format spec {format_spec} failed: {error}'.format(
+                    value=self.value,
+                    format_spec=format_spec,
+                    error=error,
+                )
+            )
+            formatted = self.value
+
+        return formatted
 
     def __repr__(self):
         return "<bumpversion.VersionPart:{}:{}>".format(

--- a/tests/test_version_part.py
+++ b/tests/test_version_part.py
@@ -45,8 +45,17 @@ def test_version_part_check_optional_true(confvpc):
 
 
 def test_version_part_format(confvpc):
-    assert "{}".format(
-        VersionPart(confvpc.first_value, confvpc)) == confvpc.first_value
+    version_part = VersionPart(confvpc.first_value, confvpc)
+
+    test_cases = [
+        ('{:04d}', '000{}'),
+        ('{:0>4}', '000{}'),
+        ('{:*^30}', '**************{}***************'),
+        ('{}', confvpc.first_value),
+    ]
+
+    for actual, expected in test_cases:
+        assert actual.format(version_part) == expected.format(confvpc.first_value)
 
 
 def test_version_part_equality(confvpc):


### PR DESCRIPTION
* fix #69
* Version parts weren't actually being formatted when serialized before.
* Formatting goes like this:
    1. Try to format val as a string
    2. If that fails, try to format val as an int
    3. If that fails, return the unformatted val, just as before