### PR TITLE
New commandline flag to not check/update the configured files

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,9 +77,9 @@ and using a configuration file (`bumpversion.cfg`) for more complex multi-file o
 
   The file that will be modified.
 
-  If not given, the list of `[bumpversion:file:…]` sections from the
-  configuration file will be used. If no files are mentioned on the
-  configuration file either, then no files will be modified.
+  This file is added to the list of files specified in `[bumpversion:file:…]`
+  sections from the configuration file. If you want to rewrite only files
+  specified on the command line, use `--no-configured-files`.
 
   Example bumping 1.1.9 to 2.0.0:
 
@@ -386,6 +386,12 @@ Additionally, the following options are available:
   Normally, bumpversion will abort if the working directory is dirty to protect
   yourself from releasing unversioned files and/or overwriting unsaved changes.
   Use this option to override this check.
+
+`--no-configured-files`
+  Will not update/check files specified in the bumpversion.cfg.
+  Similar to dry-run, but will also avoid checking the files.
+  Also useful when you want to update just one file with e.g.,
+    `bump2version --no-configured-files major my-file.txt`
 
 `--verbose`
   Print useful information to stderr

--- a/bumpversion/cli.py
+++ b/bumpversion/cli.py
@@ -103,6 +103,10 @@ def main(original_args=None):
     args, file_names = _parse_arguments_phase_3(remaining_argv, positionals, defaults, parser2)
     new_version = _parse_new_version(args, new_version, version_config)
 
+    # do not use the files from the config
+    if args.no_configured_files:
+        files = []
+
     # replace version in target files
     vcs = _determine_vcs_dirty(VCS, defaults)
     files.extend(
@@ -454,6 +458,13 @@ def _parse_arguments_phase_3(remaining_argv, positionals, defaults, parser2):
         metavar="VERSION",
         help="Version that needs to be updated",
         required="current_version" not in defaults,
+    )
+    parser3.add_argument(
+        "--no-configured-files",
+        action="store_true",
+        default=False,
+        dest="no_configured_files",
+        help="Only replace the version in files specified on the command line, ignoring the files from the configuration file.",
     )
     parser3.add_argument(
         "--dry-run",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -106,6 +106,7 @@ EXPECTED_OPTIONS = r"""
 [--search SEARCH]
 [--replace REPLACE]
 [--current-version VERSION]
+[--no-configured-files]
 [--dry-run]
 --new-version VERSION
 [--commit | --no-commit]
@@ -144,6 +145,10 @@ optional arguments:
                         {new_version})
   --current-version VERSION
                         Version that needs to be updated (default: None)
+  --no-configured-files
+                        Only replace the version in files specified on the
+                        command line, ignoring the files from the
+                        configuration file. (default: False)
   --dry-run, -n         Don't write any files, just pretend. (default: False)
   --new-version VERSION
                         New version that should be in the files (default:
@@ -2164,6 +2169,32 @@ def test_retain_newline(tmpdir, configfile, newline):
     # Ensure there is only a single newline (not two) at the end of the file
     # and that it is of the right type
     assert new_config.endswith(b"[bumpversion:file:file.py]" + newline)
+
+
+def test_no_configured_files(tmpdir, vcs):
+    tmpdir.join("please_ignore_me.txt").write("0.5.5")
+    tmpdir.chdir()
+    tmpdir.join(".bumpversion.cfg").write(dedent("""
+        [bumpversion]
+        current_version = 1.1.1
+        [bumpversion:file:please_ignore_me.txt]
+        """).strip())
+    main(['--no-configured-files', 'patch'])
+    assert "0.5.5" == tmpdir.join("please_ignore_me.txt").read()
+
+
+def test_no_configured_files_still_file_args_work(tmpdir, vcs):
+    tmpdir.join("please_ignore_me.txt").write("0.5.5")
+    tmpdir.join("please_update_me.txt").write("1.1.1")
+    tmpdir.chdir()
+    tmpdir.join(".bumpversion.cfg").write(dedent("""
+        [bumpversion]
+        current_version = 1.1.1
+        [bumpversion:file:please_ignore_me.txt]
+        """).strip())
+    main(['--no-configured-files', 'patch', "please_update_me.txt"])
+    assert "0.5.5" == tmpdir.join("please_ignore_me.txt").read()
+    assert "1.1.2" == tmpdir.join("please_update_me.txt").read()
 
 
 class TestSplitArgsInOptionalAndPositional:


### PR DESCRIPTION
Use-cases:
* just retrieving the new version without modifying/checking the files
* updating only a particular file with e.g., bump2version --no-configured-files major my-file.txt

With the `-h` text I'm not sure: I'm open for suggestions :-)