### PR TITLE
Strip trailing white spaces before saving the config

### DIFF
--- a/bumpversion/cli.py
+++ b/bumpversion/cli.py
@@ -650,7 +650,10 @@ def _update_config_file(
 
         if write_to_config_file:
             with open(config_file, "wt", encoding="utf-8", newline=config_newlines) as f:
-                f.write(new_config.getvalue().strip() + "\n")
+                config_lines = new_config.getvalue().strip().split("\n")
+                # prevent tailing white spaces
+                config_lines = [line.rstrip(" ") + "\n" for line in config_lines]
+                f.writelines(config_lines)
 
     except UnicodeEncodeError:
         warnings.warn(


### PR DESCRIPTION
First of all thanks for the nice tool, I have used it for 3 years and together with a CD system, releasing a new version of your package is a  breeze 😄 

Recently I made my first `setup.cfg` only package (bare minimum `setup.py`) and when I wanted to bump the version with (`commit = True` and `tag = True` settings as usual), my pre-commit hook removing trailing white spaces failed, rendering me unable to make a commit.

After some investigating I found that `bump2version` generates the following unwanted diff:

```diff
--- a/setup.cfg
+++ b/setup.cfg
...
-classifiers =
+classifiers = 
        Development Status :: 4 - Beta
....
-console_scripts =
+console_scripts = 
        my_programm = route.to:cli
```

Since many people have editor settings and/or other measures to remove trailing white spaces, and I don't know of any reason to add them, I decided to make this ninja PR, which makes `bump2version` remove them by default.

Since the line spitting is closely related to the used newline character, I integrated the test into `test_retain_newline`.

### Confusing black magic

Even so splitting lines which have `\r` as newline character, with `\n` shouldn't work in theory it somehow does.
Also, I found that the passed value of `config_newlines` in the tests is often `None`, which is why tests failed when I tried to split on `config_newlines` or simply use `.splitlines()`.
This is also the reason why I had to manually add back the `\n`, instead of `.writelines` taking care of that.

The only way for `config_newlines` to be `None`, without any other issues, would be if the file wasn't read before retrieving `newlines` from the file descriptor. 
But it is read before:
https://github.com/c4urself/bump2version/blob/8e6db2370a683f17a4188d8b4cc8968bac881c56/bumpversion/cli.py#L270-L272

And the function where it is read is always called:
https://github.com/c4urself/bump2version/blob/8e6db2370a683f17a4188d8b4cc8968bac881c56/bumpversion/cli.py#L89-L91

So I'm very confused and have the 2nd biggest problem in programming, 'It works and I don't know why!'.Maybe you can enlighten me, about what kind of black magic is going on here 😅
