### PR TITLE
Not rewriting config file when bumping

### DIFF
--- a/bumpversion/cli.py
+++ b/bumpversion/cli.py
@@ -130,9 +130,9 @@ def main(original_args=None):
     _log_list(config, args.new_version)
 
     # store the new version
-    # _update_config_file(
-    #     config, config_file, config_newlines, config_file_exists, args.new_version, args.dry_run,
-    # )
+    _update_config_file(
+        config, config_file, config_newlines, config_file_exists, args.new_version, args.dry_run,
+    )
 
     # commit and tag
     if vcs:
@@ -641,7 +641,7 @@ def _update_config_file(
     config.set("bumpversion", "current_version", new_version)
     new_config = io.StringIO()
     try:
-        write_to_config_file = (not dry_run) and config_file_exists
+        write_to_config_file = (not dry_run) and not config_file_exists
 
         logger.info(
             "%s to config file %s:",

--- a/bumpversion/cli.py
+++ b/bumpversion/cli.py
@@ -123,7 +123,11 @@ def main(original_args=None):
     )
 
     if config_file_exists and config_file not in files:
-        files.extend([ConfiguredFile(config_file, version_config)])
+        config_version_config = VersionConfig(parse=known_args.parse,
+                                              serialize=known_args.serialize,
+                                              search="{current_version}",
+                                              replace="{new_version}")
+        files.extend([ConfiguredFile(config_file, config_version_config)])
 
     _check_files_contain_version(files, current_version, context)
     _replace_version_in_files(files, current_version, new_version, args.dry_run, context)

--- a/bumpversion/cli.py
+++ b/bumpversion/cli.py
@@ -121,14 +121,18 @@ def main(original_args=None):
         for file_name
         in (file_names or positionals[1:])
     )
+
+    if config_file_exists and config_file not in files:
+        files.extend([ConfiguredFile(config_file, version_config)])
+
     _check_files_contain_version(files, current_version, context)
     _replace_version_in_files(files, current_version, new_version, args.dry_run, context)
     _log_list(config, args.new_version)
 
     # store the new version
-    _update_config_file(
-        config, config_file, config_newlines, config_file_exists, args.new_version, args.dry_run,
-    )
+    # _update_config_file(
+    #     config, config_file, config_newlines, config_file_exists, args.new_version, args.dry_run,
+    # )
 
     # commit and tag
     if vcs:


### PR DESCRIPTION
Since pr #90 stalled, I fixed the missing tests. By doing that, it also uncovered some regressions.
1. when current_version did not exist in .bumpversion.cfg, it will not be created:
  * when retrieving the version from the git tag
  * when retrieving the version via --current_version flag
2. when .bumpversion.cfg contains a "new_version" field, previously this
  field was removed, but with this change it is not possible anymore

Solutions:
Not staying backwards compatible, because:
 1. is a relatively uncommon, once this case happens the file has the "current_version" written afterwards, so it might not affect many
 2. even if there is a use-case for this, it can be easily migrated to print an error when new_version is found in the config and recommend "--new_version="

Staying backwards compatible, but being less intuitive:
Additionally, write the file whenever case 1 or 2 is true. This can be implemented by letting _load_configuration return a boolean.

This would solve:
* #87 #62 
* #161 
And would simplify the implementation for #42, since only a toml-parser but not printer is required