### PR TITLE
Not require to rewrite full cfg-file when bumping the version

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,13 @@ tag = True
 If no `.bumpversion.cfg` exists, `bump2version` will also look into
 `setup.cfg` for configuration.
 
+Beware: the default operation of bump2version is rewriting the complete file, causing
+the loss of comments and custom formatting. To avoid this, add the cfg-file itself to
+be bumped by bump2version. Like:
+```ini
+[bumpversion:file:.bumpversion.cfg]
+```
+
 ### Configuration file -- Global configuration
 
 General configuration is grouped in a `[bumpversion]` section.

--- a/bumpversion/cli.py
+++ b/bumpversion/cli.py
@@ -130,9 +130,9 @@ def main(original_args=None):
     _log_list(config, args.new_version)
 
     # store the new version
-    # _update_config_file(
-    #     config, config_file, config_newlines, config_file_exists, args.new_version, args.dry_run,
-    # )
+    _update_config_file(
+        config, config_file, config_newlines, config_file_exists, args.new_version, args.dry_run,
+    )
 
     # commit and tag
     if vcs:
@@ -641,7 +641,7 @@ def _update_config_file(
     config.set("bumpversion", "current_version", new_version)
     new_config = io.StringIO()
     try:
-        write_to_config_file = (not dry_run) and config_file_exists
+        write_to_config_file = (not dry_run) and not config_file_exists
 
         logger.info(
             "%s to config file %s:",

--- a/bumpversion/cli.py
+++ b/bumpversion/cli.py
@@ -121,14 +121,18 @@ def main(original_args=None):
         for file_name
         in (file_names or positionals[1:])
     )
+
+    if config_file_exists and config_file not in files:
+        files.extend([ConfiguredFile(config_file, version_config)])
+
     _check_files_contain_version(files, current_version, context)
     _replace_version_in_files(files, current_version, new_version, args.dry_run, context)
     _log_list(config, args.new_version)
 
     # store the new version
-    _update_config_file(
-        config, config_file, config_newlines, config_file_exists, args.new_version, args.dry_run,
-    )
+    # _update_config_file(
+    #     config, config_file, config_newlines, config_file_exists, args.new_version, args.dry_run,
+    # )
 
     # commit and tag
     if vcs:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2250,6 +2250,24 @@ def test_no_configured_files_still_file_args_work(tmpdir, vcs):
     assert "1.1.2" == tmpdir.join("please_update_me.txt").read()
 
 
+def test_cfg_files_not_rewritten_when_specified(tmpdir):
+    """ when the .bumpversion.cfg is specified as a file to be bumped, the
+    config should not be rewritten (i.e., losing custom foratting + comments). """
+    tmpdir.chdir()
+    initial_config = """[bumpversion]
+current_version = 500.0.0
+# specify the .bumpversion.cfg here to avoid unintentionally rewriting it
+# for example comments are removed or trailing whitespaces
+[bumpversion:file:.bumpversion.cfg]   
+
+"""
+
+    tmpdir.join(".bumpversion.cfg").write(initial_config, mode='w')
+    main(['major'])
+    expected_new_config = initial_config.replace('500', '501')
+    assert expected_new_config == tmpdir.join(".bumpversion.cfg").read(mode='r')
+
+
 class TestSplitArgsInOptionalAndPositional:
 
     def test_all_optional(self):


### PR DESCRIPTION
Since pr #90 introduced a lot of breaking changes (can bee seen in the updated unit tests in #162 ). Here is another approach. Basically it makes it opt-in to use bump2version on the `.bumpversion.cfg` rather than the opt-out approach of #90.

When this PR is merged it solves #87, #62, and provides a solution for #161 
