### PR TITLE
Allow setting `allow_dirty=False` in the config file

### DIFF
--- a/bumpversion/cli.py
+++ b/bumpversion/cli.py
@@ -294,7 +294,7 @@ def _load_configuration(config_file, explicit_config, defaults):
         except NoOptionError:
             pass  # no default value then ;)
 
-    for boolvaluename in ("commit", "tag", "dry_run", "allow-dirty", "push", "sign_tags"):
+    for boolvaluename in ("commit", "tag", "dry_run", "allow_dirty", "push", "sign_tags"):
         try:
             defaults[boolvaluename] = config.getboolean(
                 "bumpversion", boolvaluename

--- a/bumpversion/cli.py
+++ b/bumpversion/cli.py
@@ -59,6 +59,14 @@ logger = logging.getLogger(__name__)
 time_context = {"now": datetime.now(), "utcnow": datetime.utcnow()}
 special_char_context = {c: c for c in ("#", ";")}
 
+FLAG_ARGUMENTS = [
+    "commit",
+    "tag",
+    "dry_run",
+    "allow_dirty",
+    "push",
+    "sign_tags",
+]
 
 OPTIONAL_ARGUMENTS_THAT_TAKE_VALUES = [
     "--config-file",
@@ -294,13 +302,13 @@ def _load_configuration(config_file, explicit_config, defaults):
         except NoOptionError:
             pass  # no default value then ;)
 
-    for boolvaluename in ("commit", "tag", "dry_run", "allow_dirty", "push", "sign_tags"):
+    for flag_argument in FLAG_ARGUMENTS:
         try:
-            defaults[boolvaluename] = config.getboolean(
-                "bumpversion", boolvaluename
+            defaults[flag_argument] = config.getboolean(
+                "bumpversion", flag_argument
             )
         except NoOptionError:
-            pass  # no default value then ;)
+            pass  # no default value then (like, False-y)
 
     part_configs = {}
     files = []

--- a/bumpversion/cli.py
+++ b/bumpversion/cli.py
@@ -294,7 +294,7 @@ def _load_configuration(config_file, explicit_config, defaults):
         except NoOptionError:
             pass  # no default value then ;)
 
-    for boolvaluename in ("commit", "tag", "dry_run"):
+    for boolvaluename in ("commit", "tag", "dry_run", "allow-dirty", "push", "sign_tags"):
         try:
             defaults[boolvaluename] = config.getboolean(
                 "bumpversion", boolvaluename


### PR DESCRIPTION
This fixes a bug as was discussed and fixed in #180.

Symptoms: setting `allow_dirty` to `False` in the config file does not actually make it `False`.