### PR TITLE
New side_effect config option for version parts

### DIFF
--- a/bumpversion/functions.py
+++ b/bumpversion/functions.py
@@ -114,8 +114,11 @@ class ValuesFunction:
 
     def bump(self, value, version=None):
         try:
-            _execute_conditional_bump(self.conditional_bump, version)
-            return self._values[self._values.index(value) + 1]
+            parts_conditionally_bumped = _execute_conditional_bump(self.conditional_bump, version)
+            return (
+                self._values[self._values.index(value) + 1],
+                parts_conditionally_bumped
+            )
         except IndexError:
             raise ValueError(
                 "The part has already the maximum value among {} and cannot be bumped.".format(

--- a/bumpversion/functions.py
+++ b/bumpversion/functions.py
@@ -54,7 +54,7 @@ def _get_function_from_path(path: str):
     if path is not None:
         # Path could be `something.module.function`, we want just `something.module`
         # and then get just `function`.
-        module_path = "".join(path.split(".")[:-1])
+        module_path = ".".join(path.split(".")[:-1])
         function_name = path.split(".")[-1]
         module = import_module(module_path)
         return getattr(module, function_name)

--- a/bumpversion/functions.py
+++ b/bumpversion/functions.py
@@ -18,7 +18,7 @@ class NumericFunction:
 
     FIRST_NUMERIC = re.compile(r"([^\d]*)(\d+)(.*)")
 
-    def __init__(self, first_value=None, conditional_bump=None):
+    def __init__(self, first_value=None, side_effect=None):
 
         if first_value is not None:
             try:
@@ -34,20 +34,20 @@ class NumericFunction:
 
         self.first_value = str(first_value)
         self.optional_value = self.first_value
-        self.conditional_bump = _get_function_from_path(conditional_bump)
+        self.side_effect = _get_side_effect_function(side_effect)
 
     def bump(self, value, version=None, part_key=None):
         part_prefix, part_numeric, part_suffix = self.FIRST_NUMERIC.search(
             value
         ).groups()
 
-        _execute_conditional_bump(self.conditional_bump, version)
+        _execute_side_effect(self.side_effect, version)
         bumped_numeric = _get_next_part_value(part_key, version, int(part_numeric) + 1)
 
         return "".join([part_prefix, str(bumped_numeric), part_suffix])
 
 
-def _get_function_from_path(path: str):
+def _get_side_effect_function(path: str):
     if path is not None:
         # Path could be `something.module.function`, we want just `something.module`
         # and then get just `function`.
@@ -57,15 +57,16 @@ def _get_function_from_path(path: str):
         return getattr(module, function_name)
 
 
-def _execute_conditional_bump(conditional_bump=None, version=None):
-    if conditional_bump is not None:
-        conditional_bump(version)
+def _execute_side_effect(side_effect=None, version=None):
+    if side_effect is not None:
+        side_effect(version)
 
 
 def _get_next_part_value(part_key, version, standard_value):
     """
     If the part was not manually set then it returns the `standard_value`.
     Otherwise it will return the manually set value for the target part.
+    The part may be manually set within a user's side_effect function if they have one.
     """
     if part_key is not None and version[part_key].manually_set:
         return version[part_key].value
@@ -86,7 +87,7 @@ class ValuesFunction:
     you get a ValueError exception.
     """
 
-    def __init__(self, values, optional_value=None, first_value=None, conditional_bump=None):
+    def __init__(self, values, optional_value=None, first_value=None, side_effect=None):
 
         if not values:
             raise ValueError("Version part values cannot be empty")
@@ -116,12 +117,12 @@ class ValuesFunction:
             )
 
         self.first_value = first_value
-        self.conditional_bump = _get_function_from_path(conditional_bump)
+        self.side_effect = _get_side_effect_function(side_effect)
         self.part_key = None
 
     def bump(self, value, version=None, part_key=None):
         try:
-            _execute_conditional_bump(self.conditional_bump, version)
+            _execute_side_effect(self.side_effect, version)
             bumped_value = _get_next_part_value(
                 part_key, version, self._values[self._values.index(value) + 1]
             )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1609,18 +1609,18 @@ def test_optional_value_from_documentation(tmpdir):
     assert '1' == tmpdir.join("optional_value_from_doc.txt").read()
 
 
-def test_conditional_bump(tmpdir):
+def test_side_effect_bump(tmpdir):
     import sys
     sys.path.insert(0, tmpdir.strpath)
 
-    tmpdir.join("condition_version_bump.txt").write("3.5-beta")
+    tmp_version_file = "side_effect_version.txt"
+    tmpdir.join(tmp_version_file).write("3.5-beta")
     tmpdir.chdir()
 
     tmpdir.join("__init__.py").write("")
     tmpdir.join("mybump.py").write(dedent(r"""
         def bump_patch(version):
-            if version['release'].value != 'gamma':
-                version['release'].value = 'gamma'
+            version['release'].value = 'gamma'
         """).strip())
 
     tmpdir.join(".bumpversion.cfg").write(dedent(r"""
@@ -1638,18 +1638,18 @@ def test_conditional_bump(tmpdir):
             gamma
 
         [bumpversion:part:patch]
-        conditional_bump = mybump.bump_patch
+        side_effect = mybump.bump_patch
 
-        [bumpversion:file:condition_version_bump.txt]
+        [bumpversion:file:side_effect_version.txt]
         """).strip())
 
     main(['patch', '--verbose'])
 
-    assert '3.6-gamma' == tmpdir.join("condition_version_bump.txt").read()
+    assert '3.6-gamma' == tmpdir.join(tmp_version_file).read()
 
     main(['major', '--verbose'])
 
-    assert '4.0-alpha' == tmpdir.join("condition_version_bump.txt").read()
+    assert '4.0-alpha' == tmpdir.join(tmp_version_file).read()
 
 
 def test_python_pre_release_release_post_release(tmpdir):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -311,6 +311,7 @@ new_version: 0.9.35
     assert "0.9.35" == tmpdir.join("file1.txt").read()
     assert "0.9.35" == tmpdir.join("file2.txt").read()
 
+
 def test_glob_keyword_recursive(tmpdir, configfile):
     tmpdir.mkdir("subdir").mkdir("subdir2")
     file1 = tmpdir.join("subdir").join("file1.txt")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1621,8 +1621,6 @@ def test_conditional_bump(tmpdir):
         def bump_patch(version):
             if version['release'].value != 'gamma':
                 version['release'].value = 'gamma'
-                return ['release']
-            return []
         """).strip())
 
     tmpdir.join(".bumpversion.cfg").write(dedent(r"""

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -76,7 +76,7 @@ def test_values_bump():
     assert func.bump(0) == 5
 
 
-def test_values_bump():
+def test_values_bump_with_value_error():
     func = ValuesFunction([0, 5, 10])
     with pytest.raises(ValueError):
         func.bump(10)

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -22,12 +22,12 @@ def test_numeric_init_non_numeric_first_value():
 
 def test_numeric_bump_simple_number():
     func = NumericFunction()
-    assert func.bump('0') == '1'
+    assert func.bump('0')[0] == '1'
 
 
 def test_numeric_bump_prefix_and_suffix():
     func = NumericFunction()
-    assert func.bump('v0b') == 'v1b'
+    assert func.bump('v0b')[0] == 'v1b'
 
 
 # ValuesFunction
@@ -73,7 +73,7 @@ def test_values_init_w_incorrect_first_value():
 
 def test_values_bump():
     func = ValuesFunction([0, 5, 10])
-    assert func.bump(0) == 5
+    assert func.bump(0)[0] == 5
 
 
 def test_values_bump_with_value_error():

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -22,12 +22,12 @@ def test_numeric_init_non_numeric_first_value():
 
 def test_numeric_bump_simple_number():
     func = NumericFunction()
-    assert func.bump('0')[0] == '1'
+    assert func.bump('0') == '1'
 
 
 def test_numeric_bump_prefix_and_suffix():
     func = NumericFunction()
-    assert func.bump('v0b')[0] == 'v1b'
+    assert func.bump('v0b') == 'v1b'
 
 
 # ValuesFunction
@@ -73,7 +73,7 @@ def test_values_init_w_incorrect_first_value():
 
 def test_values_bump():
     func = ValuesFunction([0, 5, 10])
-    assert func.bump(0)[0] == 5
+    assert func.bump(0) == 5
 
 
 def test_values_bump_with_value_error():

--- a/tests/test_version_part.py
+++ b/tests/test_version_part.py
@@ -62,11 +62,10 @@ def test_version_part_null(confvpc):
         confvpc.first_value, confvpc)
 
 
-# Conditional bumping
+# Side effect
 
 def bump_patch(version: Version):
-    if version["release"].value != "gamma":
-        version["release"].value = "gamma"
+    version["release"].value = "gamma"
     if version["major"].value == '9':
         int_val = int(version["patch"].value)
         new_val = int_val + 2
@@ -74,9 +73,9 @@ def bump_patch(version: Version):
 
 
 @pytest.fixture
-@mock.patch("bumpversion.functions._get_function_from_path")
-def version_config(mock_conditional):
-    mock_conditional.return_value = bump_patch
+@mock.patch("bumpversion.functions._get_side_effect_function")
+def version_config(mock_get_function):
+    mock_get_function.return_value = bump_patch
 
     release_part_config = ConfiguredVersionPartConfiguration(
         first_value="beta",
@@ -85,7 +84,7 @@ def version_config(mock_conditional):
     )
     patch_part_config = NumericVersionPartConfiguration(
         first_value="1",
-        conditional_bump="my.function"
+        side_effect="my.function"
     )
     version_config = VersionConfig(
         parse=r"(?P<major>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+))?",
@@ -100,13 +99,13 @@ def version_config(mock_conditional):
     return version_config
 
 
-def test_version_conditional_bump_optional_value(version_config):
+def test_version_side_effect_bump_optional_value(version_config):
     version = version_config.parse("2.4-beta")
     new_version = version.bump("patch", version_config.order())
     assert version_config.serialize(new_version, {}) == "2.5"
 
 
-def test_version_conditional_bump_required_value(version_config):
+def test_version_side_effect_bump_required_value(version_config):
     version_config.part_configs["release"].function.optional_value = None
 
     version = version_config.parse("2.4-beta")
@@ -114,7 +113,7 @@ def test_version_conditional_bump_required_value(version_config):
     assert version_config.serialize(new_version, {}) == "2.5-gamma"
 
 
-def test_version_conditional_bump_self_bump(version_config):
+def test_version_side_effect_bump_self_bump(version_config):
     version = version_config.parse("9.4-beta")
     new_version = version.bump("patch", version_config.order())
     assert version_config.serialize(new_version, {}) == "9.6"

--- a/tests/test_version_part.py
+++ b/tests/test_version_part.py
@@ -35,12 +35,12 @@ def test_version_part_copy(confvpc):
 
 def test_version_part_bump(confvpc):
     vp = VersionPart(confvpc.first_value, confvpc)
-    vc = vp.bump()
-    assert vc.value == confvpc.bump(confvpc.first_value)
+    vc = vp.bump()[0]
+    assert vc.value == confvpc.bump(confvpc.first_value)[0]
 
 
 def test_version_part_check_optional_false(confvpc):
-    assert not VersionPart(confvpc.first_value, confvpc).bump().is_optional()
+    assert not VersionPart(confvpc.first_value, confvpc).bump()[0].is_optional()
 
 
 def test_version_part_check_optional_true(confvpc):

--- a/tests/test_version_part.py
+++ b/tests/test_version_part.py
@@ -35,12 +35,12 @@ def test_version_part_copy(confvpc):
 
 def test_version_part_bump(confvpc):
     vp = VersionPart(confvpc.first_value, confvpc)
-    vc = vp.bump()[0]
-    assert vc.value == confvpc.bump(confvpc.first_value)[0]
+    vc = vp.bump()
+    assert vc.value == confvpc.bump(confvpc.first_value)
 
 
 def test_version_part_check_optional_false(confvpc):
-    assert not VersionPart(confvpc.first_value, confvpc).bump()[0].is_optional()
+    assert not VersionPart(confvpc.first_value, confvpc).bump().is_optional()
 
 
 def test_version_part_check_optional_true(confvpc):
@@ -67,8 +67,10 @@ def test_version_part_null(confvpc):
 def bump_patch(version: Version):
     if version["release"].value != "gamma":
         version["release"].value = "gamma"
-        return ["release"]
-    return []
+    if version["major"].value == '9':
+        int_val = int(version["patch"].value)
+        new_val = int_val + 2
+        version["patch"].value = str(new_val)
 
 
 @pytest.fixture
@@ -111,3 +113,8 @@ def test_version_conditional_bump_required_value(version_config):
     new_version = version.bump("patch", version_config.order())
     assert version_config.serialize(new_version, {}) == "2.5-gamma"
 
+
+def test_version_conditional_bump_self_bump(version_config):
+    version = version_config.parse("9.4-beta")
+    new_version = version.bump("patch", version_config.order())
+    assert version_config.serialize(new_version, {}) == "9.6"

--- a/tests/test_version_part.py
+++ b/tests/test_version_part.py
@@ -1,9 +1,12 @@
 import pytest
+from unittest import mock
 
 from bumpversion.version_part import (
     ConfiguredVersionPartConfiguration,
     NumericVersionPartConfiguration,
     VersionPart,
+    VersionConfig,
+    Version,
 )
 
 
@@ -57,3 +60,54 @@ def test_version_part_equality(confvpc):
 def test_version_part_null(confvpc):
     assert VersionPart(confvpc.first_value, confvpc).null() == VersionPart(
         confvpc.first_value, confvpc)
+
+
+# Conditional bumping
+
+def bump_patch(version: Version):
+    if version["release"].value != "gamma":
+        version["release"].value = "gamma"
+        return ["release"]
+    return []
+
+
+@pytest.fixture
+@mock.patch("bumpversion.functions._get_function_from_path")
+def version_config(mock_conditional):
+    mock_conditional.return_value = bump_patch
+
+    release_part_config = ConfiguredVersionPartConfiguration(
+        first_value="beta",
+        optional_value="gamma",
+        values=["beta", "gamma"],
+    )
+    patch_part_config = NumericVersionPartConfiguration(
+        first_value="1",
+        conditional_bump="my.function"
+    )
+    version_config = VersionConfig(
+        parse=r"(?P<major>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+))?",
+        serialize=["{major}.{patch}-{release}", "{major}.{patch}"],
+        part_configs={
+            "release": release_part_config,
+            "patch": patch_part_config,
+        },
+        search=None,
+        replace=None,
+    )
+    return version_config
+
+
+def test_version_conditional_bump_optional_value(version_config):
+    version = version_config.parse("2.4-beta")
+    new_version = version.bump("patch", version_config.order())
+    assert version_config.serialize(new_version, {}) == "2.5"
+
+
+def test_version_conditional_bump_required_value(version_config):
+    version_config.part_configs["release"].function.optional_value = None
+
+    version = version_config.parse("2.4-beta")
+    new_version = version.bump("patch", version_config.order())
+    assert version_config.serialize(new_version, {}) == "2.5-gamma"
+


### PR DESCRIPTION
This is a feature that will fulfill #190 which I create a while ago.

### Feature description
You can use the `side_effect` attribute for part bumps inside the bump2version config. This means you can execute your own python code along with the bumping of a part. You can also manually set the version parts, and avoid the default bumping of any part value that you set. Within your project you can store the side_effect functions in any module, although the module needs to be discoverable by python. Meaning that the `PYTHONPATH` environment variable needs to be set to the project's base directory, or the base directory needs to be in `sys.path`. You would reference the function similarly to an import statement in python (e.g. `package.module.function`)

_It would be nice to have this feature work out of the box, without the user needing to set `PYTHONPATH` or `sys.path`, but I am not aware of a way to work around this._

### Example
This example is one that will resolve my issue outlined in #190, and since this gives complete control, that means this solution can avoid the pitfall of the initial `reset_with` suggestion:

> This solution has a pitfall though. If there is a version of 3.8.5-beta.2, if the patch part is not in the reset_with list, then bumping the patch will go from 3.8.5-beta.2 -> 3.8.6-beta.2.

Notice the `side_effect` inside the `[bumpversion:part:patch]` config section.

```ini
# setup.cfg
[bumpversion]
current_version = 3.8.4
parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<pre>[a-z]+)\.(?P<build>\d+))?
serialize = 
    {major}.{minor}.{patch}-{pre}.{build}
    {major}.{minor}.{patch}

[bumpversion:part:patch]
side_effect = mybump.bump_patch

[bumpversion:part:pre]
first_value = alpha
optional_value = gamma
values = 
    alpha
    beta
    rc
    gamma

[bumpversion:part:build]
first_value = 1
```

```python
# mybump.py
def bump_patch(version):
    version["pre"].value = "gamma"
    version["build"].value = "1"
```

- **With** the `side_effect` set, `bump2version patch` results in a version of `3.8.5`.
- **Without** the `side_effect` set, `bump2version patch` results in a version of `3.8.5-alpha.1`.

My custom side effect is being executed and will set the `pre` and `build` part of the version manually. The side effect will only get executed for a `patch` bump, and does not override the bumps of any other part under this config. So a `bump2version major` will give a version of `4.0.0-alpha.1`, which is the default expected behaviour.

### My thoughts
I initially started out with a `conditional_bump` config option, because my use case was to just bump parts conditionally based on other parts. Then I realised that this opens up a lot of custom automation possibilities for people. After implementing this I can also see a way to easily implement something like a `pre_bump` and a `post_bump` for executing code before or after a bump - this would open up even more automation possibilities. A `pre_bump` and `post_bump` should provide the version values, but not allow the user to change the values, maybe this can be a topic for future discussion.