### PR TITLE
Load cli args before config file

### DIFF
--- a/bumpversion/cli.py
+++ b/bumpversion/cli.py
@@ -39,7 +39,7 @@ from bumpversion.vcs import Git, Mercurial
 DESCRIPTION = "{}: v{} (using Python v{})".format(
     __title__,
     __version__,
-    sys.version.split("\n")[0].split(" ")[0]
+    sys.version.split("\n", maxsplit=1)[0].split(" ", maxsplit=1)[0]
 )
 VCS = [Git, Mercurial]
 
@@ -86,7 +86,9 @@ def main(original_args=None):
     if hasattr(known_args, "config_file"):
         explicit_config = known_args.config_file
     config_file = _determine_config_file(explicit_config)
-    config, config_file_exists, config_newlines = _load_configuration_file(config_file, explicit_config, defaults)
+    config, config_file_exists, config_newlines = _load_configuration_file(config_file,
+                                                                           explicit_config,
+                                                                           defaults)
     known_args, parser2, remaining_argv = _parse_arguments_phase_2(
         args, known_args, defaults, root_parser
     )
@@ -478,7 +480,8 @@ def _parse_arguments_phase_3(remaining_argv, positionals, defaults, parser2):
         action="store_true",
         default=False,
         dest="no_configured_files",
-        help="Only replace the version in files specified on the command line, ignoring the files from the configuration file.",
+        help="Only replace the version in files specified on the command line, "
+             "ignoring the files from the configuration file.",
     )
     parser3.add_argument(
         "--dry-run",


### PR DESCRIPTION
# Description 

Hi I'm opening this PR to address this issue: https://github.com/c4urself/bump2version/issues/231

I am modifying the configuration loading piece of bump2version so that the cli arguments take precedence over the configurations in the file.

## Behavior before pull request Example

### Step 1 create .bumpversion.cfg and version.txt

.bumpversion.cfg

```ini
[bumpversion]
current_version = 0.8.0
serialize = {major}.{minor}
parse = (?P<major>\d+)\.(?P<minor>\d+)(\.(?P<patch>\d+))?

[bumpversion:file:version.txt]

```

version.txt:

```txt
0.8.0
```

### Run bump2version

```
$ bump2version patch --serialize "{major}.{minor}.{patch}" --list
current_version=0.8.0
serialize={major}.{minor}
parse=(?P<major>\d+)\.(?P<minor>\d+)(\.(?P<patch>\d+))?
new_version=0.8.1
```

### Results

- .bumpversion.cfg == 0.8.1
- version.txt == 0.8

## Behavior after changes

```ini
[bumpversion]
current_version = 0.8.0
serialize = {major}.{minor}
parse = (?P<major>\d+)\.(?P<minor>\d+)(\.(?P<patch>\d+))?

[bumpversion:file:version.txt]

```

version.txt:

```txt
0.8.0
```

### Run bump2version

```
$ bump2version patch --serialize "{major}.{minor}.{patch}" --list
current_version=0.8.0
serialize={major}.{minor}
parse=(?P<major>\d+)\.(?P<minor>\d+)(\.(?P<patch>\d+))?
new_version=0.8.1
```

### Results

- .bumpversion.cfg == 0.8.1
- version.txt == 0.8.1
