### PR TITLE
Implementation of the independent feature from ADVbumpversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,32 @@ first_value = 1
   `bump2version release` would bump `1.alpha1` to `1.beta0`, starting
   the build at `0`.
 
+
+#### `independent =`
+  **default**: `False`
+
+  When this value is set to `True`, the part is not reset when other parts are incremented. Its incrementation is
+  independent of the other parts. It is in particular useful when you have a build number in your version that is
+  incremented independently of the actual version.
+
+  Example:
+
+```ini
+[bumpversion]
+current_version: 2.1.6-5123
+parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)\-(?P<build>\d+)
+serialize = {major}.{minor}.{patch}-{build}
+
+[bumpversion:file:VERSION.txt]
+
+[bumpversion:part:build]
+independent = True
+```
+
+  Here, `bump2version build` would bump `2.1.6-5123` to `2.1.6-5124`. Executing`bump2version major`
+  would bump `2.1.6-5124` to `3.0.0-5124` without resetting the build number.
+  
+
 ### Configuration file -- File specific configuration
 
 This configuration is in the section: `[bumpversion:file:…]` or `[bumpversion:glob:…]`

--- a/RELATED.md
+++ b/RELATED.md
@@ -7,8 +7,9 @@
 * [tbump](https://github.com/tankerhq/tbump) is a complete rewrite, with a nicer UX and additional features, like running commands (aka hooks) before or after the bump. It only works for Git repos right now.
 
 * [ADVbumpversion](https://github.com/andrivet/advbumpversion) is another fork.
-  It offers some features which are still work in progress here; it's
-  definitely our desire to merge back (issue [#121](https://github.com/c4urself/bump2version/issues/121)).
+  It offered some features that are now incorporated by its author into `bump2version`. 
+  This fork is thus now deprecated, and it recommends to use `bump2version`
+  (issue [#121](https://github.com/c4urself/bump2version/issues/121)).
 
 * [zest.releaser](https://pypi.org/project/zest.releaser/) manages
   your Python package releases and keeps the version number in one location.

--- a/bumpversion/cli.py
+++ b/bumpversion/cli.py
@@ -327,6 +327,9 @@ def _load_configuration(config_file, explicit_config, defaults):
                 )
                 ThisVersionPartConfiguration = ConfiguredVersionPartConfiguration
 
+            if config.has_option(section_name, 'independent'):
+                section_config['independent'] = config.getboolean(section_name, 'independent')
+
             part_configs[section_value] = ThisVersionPartConfiguration(
                 **section_config
             )

--- a/bumpversion/functions.py
+++ b/bumpversion/functions.py
@@ -17,7 +17,7 @@ class NumericFunction:
 
     FIRST_NUMERIC = re.compile(r"([^\d]*)(\d+)(.*)")
 
-    def __init__(self, first_value=None):
+    def __init__(self, first_value=None, independent=False):
 
         if first_value is not None:
             try:
@@ -33,6 +33,7 @@ class NumericFunction:
 
         self.first_value = str(first_value)
         self.optional_value = self.first_value
+        self.independent = independent
 
     def bump(self, value):
         part_prefix, part_numeric, part_suffix = self.FIRST_NUMERIC.search(
@@ -57,7 +58,7 @@ class ValuesFunction:
     you get a ValueError exception.
     """
 
-    def __init__(self, values, optional_value=None, first_value=None):
+    def __init__(self, values, optional_value=None, first_value=None, independent=False):
 
         if not values:
             raise ValueError("Version part values cannot be empty")
@@ -87,6 +88,7 @@ class ValuesFunction:
             )
 
         self.first_value = first_value
+        self.independent = independent
 
     def bump(self, value):
         try:

--- a/bumpversion/version_part.py
+++ b/bumpversion/version_part.py
@@ -30,6 +30,10 @@ class PartConfiguration:
     def optional_value(self):
         return str(self.function.optional_value)
 
+    @property
+    def independent(self):
+        return self.function.independent
+
     def bump(self, value=None):
         return self.function.bump(value)
 
@@ -72,6 +76,9 @@ class VersionPart:
 
     def is_optional(self):
         return self.value == self.config.optional_value
+
+    def is_independent(self):
+        return self.config.independent
 
     def __format__(self, format_spec):
         return self.value
@@ -117,7 +124,7 @@ class Version:
             if label == part_name:
                 new_values[label] = self._values[label].bump()
                 bumped = True
-            elif bumped:
+            elif bumped and not self._values[label].is_independent():
                 new_values[label] = self._values[label].null()
             else:
                 new_values[label] = self._values[label].copy()


### PR DESCRIPTION
This is an implementation (back port) of the `independent` feature from ADVbumpversion, as discussed in #121. This feature implements #81.  If this PR can be merged, I will close ADVbumpversion fork and redirect people to bump2version.