### PR TITLE
Fix expected usage string for tests

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -117,7 +117,7 @@ EXPECTED_OPTIONS = r"""
 [--tag-message TAG_MESSAGE]
 [--message COMMIT_MSG]
 part
-[file [file ...]]
+[file ...]
 """.strip().splitlines()
 
 EXPECTED_USAGE = (r"""
@@ -247,7 +247,7 @@ new_version: 19
     assert "New version that should be in the files (default: 19)" in out
     assert "[--current-version VERSION]" in out
     assert "[--new-version VERSION]" in out
-    assert "[file [file ...]]" in out
+    assert "[file ...]" in out
 
 
 def test_missing_explicit_config_file(tmpdir):


### PR DESCRIPTION
Some tests fail for me on Python 3.7.12, 3.8.12 and 3.9.6 because the expected usage string contains `[file [file ...]]` instead of `[file ...]`.

I ran the tests on NixOS instead of Docker. The Dockerfile appears quite outdated to me -- maybe it would be worth to update it.