### PR TITLE
Drop py36, add tests against py39

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,6 @@ jobs:
           - "3.7"
           - "3.8"
           - "3.9"
-          - "3.10"
           - "pypy-3.8"
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,10 +18,11 @@ jobs:
           - ubuntu-latest
           - windows-latest
         python-version:
-          - "3.6"
           - "3.7"
           - "3.8"
-          - "pypy-3.7"
+          - "3.9"
+          - "3.10"
+          - "pypy-3.8"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 **v1.0.2-dev**
 - Housekeeping: migrated from travis+appveyor to GitHub Actions for CI, thanks @clbarnes
 - Drop Python3.6 support, thanks @clbarnes
-- Add Python3.9, Python3.10 support, thanks @clbarnes
+- Add Python3.9, thanks @clbarnes
 
 **v1.0.1**
 - Added: enable special characters in search/replace, thanks @mckelvin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 **unreleased**
 **v1.0.2-dev**
 - Housekeeping: migrated from travis+appveyor to GitHub Actions for CI, thanks @clbarnes
+- Drop Python3.6 support, thanks @clbarnes
+- Add Python3.9, Python3.10 support, thanks @clbarnes
 
 **v1.0.1**
 - Added: enable special characters in search/replace, thanks @mckelvin

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1405,8 +1405,8 @@ def test_subjunctive_dry_run_logging(tmpdir, vcs):
         commit = True
         tag = True
         serialize =
-            {major}.{minor}.{patch}
-            {major}.{minor}
+        	{major}.{minor}.{patch}
+        	{major}.{minor}
         parse = (?P<major>\d+)\.(?P<minor>\d+)(\.(?P<patch>\d+))?
         [bumpversion:file:dont_touch_me.txt]
     """).strip())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -171,6 +171,10 @@ optional arguments:
 """ % DESCRIPTION).lstrip()
 
 
+def normalize_whitespace(s):
+    return " ".join(s.split())
+
+
 def test_usage_string(tmpdir, capsys):
     tmpdir.chdir()
 
@@ -183,7 +187,7 @@ def test_usage_string(tmpdir, capsys):
     for option_line in EXPECTED_OPTIONS:
         assert option_line in out, "Usage string is missing {}".format(option_line)
 
-    assert EXPECTED_USAGE in out
+    assert normalize_whitespace(EXPECTED_USAGE) in normalize_whitespace(out)
 
 
 def test_usage_string_fork(tmpdir):
@@ -227,7 +231,7 @@ def test_regression_help_in_work_dir(tmpdir, capsys, vcs):
     if vcs == "git":
         assert "Version that needs to be updated (default: 1.7.2013)" in out
     else:
-        assert EXPECTED_USAGE in out
+        assert normalize_whitespace(EXPECTED_USAGE) in normalize_whitespace(out)
 
 
 def test_defaults_in_usage_with_config(tmpdir, capsys):
@@ -1401,8 +1405,8 @@ def test_subjunctive_dry_run_logging(tmpdir, vcs):
         commit = True
         tag = True
         serialize =
-        	{major}.{minor}.{patch}
-        	{major}.{minor}
+            {major}.{minor}.{patch}
+            {major}.{minor}
         parse = (?P<major>\d+)\.(?P<minor>\d+)(\.(?P<patch>\d+))?
         [bumpversion:file:dont_touch_me.txt]
     """).strip())
@@ -1893,11 +1897,11 @@ def test_non_matching_search_does_not_modify_file(tmpdir):
 
     changelog_content = dedent("""
     # Unreleased
-    
+
     * bullet point A
-    
+
     # Release v'older' (2019-09-17)
-    
+
     * bullet point B
     """)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -171,10 +171,6 @@ optional arguments:
 """ % DESCRIPTION).lstrip()
 
 
-def normalize_whitespace(s):
-    return " ".join(s.split())
-
-
 def test_usage_string(tmpdir, capsys):
     tmpdir.chdir()
 
@@ -187,7 +183,7 @@ def test_usage_string(tmpdir, capsys):
     for option_line in EXPECTED_OPTIONS:
         assert option_line in out, "Usage string is missing {}".format(option_line)
 
-    assert normalize_whitespace(EXPECTED_USAGE) in normalize_whitespace(out)
+    assert EXPECTED_USAGE in out
 
 
 def test_usage_string_fork(tmpdir):
@@ -231,7 +227,7 @@ def test_regression_help_in_work_dir(tmpdir, capsys, vcs):
     if vcs == "git":
         assert "Version that needs to be updated (default: 1.7.2013)" in out
     else:
-        assert normalize_whitespace(EXPECTED_USAGE) in normalize_whitespace(out)
+        assert EXPECTED_USAGE in out
 
 
 def test_defaults_in_usage_with_config(tmpdir, capsys):
@@ -1897,11 +1893,11 @@ def test_non_matching_search_does_not_modify_file(tmpdir):
 
     changelog_content = dedent("""
     # Unreleased
-
+    
     * bullet point A
-
+    
     # Release v'older' (2019-09-17)
-
+    
     * bullet point B
     """)
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35, py36, py37, py38, pypy3
+envlist = py37, py38, py39, py310, pypy3
 
 [testenv]
 passenv = HOME
@@ -16,8 +16,8 @@ python_files = test*.py
 
 [gh-actions]
 python =
-    2.7: py27
-    3.6: py36
     3.7: py37
     3.8: py38, mypy
-    pypy-3.7: pypy3
+    3.9: py38
+    3.10: py310
+    pypy-3.8: pypy3

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37, py38, py39, py310, pypy3
+envlist = py37, py38, py39, pypy3
 
 [testenv]
 passenv = HOME
@@ -19,5 +19,4 @@ python =
     3.7: py37
     3.8: py38, mypy
     3.9: py38
-    3.10: py310
     pypy-3.8: pypy3


### PR DESCRIPTION
Supersedes #226 , as it uses the GHA config.

Originally included 3.10 as well but there's some subtle difference in the `--help` output format which needs a bit more care, where this goes in nice and easy.