### PR TITLE
[Enhancement] Create CITATION.cff and Validation (#1)

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -16,6 +16,10 @@ search = **unreleased**
 replace = **unreleased**
 	**v{new_version}**
 
+[bumpversion:file:CITATION.cff]
+search = version: {current_version}
+replace = version: {new_version}
+
 [bumpversion:part:release]
 optional_value = gamma
 values = 

--- a/.github/workflows/cffconvert.yml
+++ b/.github/workflows/cffconvert.yml
@@ -1,0 +1,24 @@
+name: cffconvert
+
+on:
+  push:
+    paths:
+      - CITATION.cff
+
+permissions:
+  contents: read
+
+jobs:
+  validation:
+    name: validate
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+        with:
+          persist-credentials: false
+
+      - name: cffconvert
+        uses: citation-file-format/cffconvert-github-action@4cf11baa70a673bfdf9dad0acc7ee33b3f4b6084
+        with:
+          args: "--validate"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,19 @@
+# Parser information.
+cff-version: 1.2.0
+message: Please cite this software using these meta data.
+
+# Version information.
+date-released: 2020-10-07
+version: 1.0.2-dev
+
+# Project information.
+abstract: Version-bump your software with a single command!
+authors:
+  - alias: c4urself
+    family-names: Verkerk
+    given-names: Christian
+  - name: The bump2version Community
+license: MIT
+repository-code: https://github.com/c4urself/bump2version
+title: bump2version
+url: https://pypi.python.org/pypi/bump2version


### PR DESCRIPTION
Dear maintainers,

Thank you for your software!  I encountered bump2version first a few days ago and directly tested it in some of my repositories.  Since I frequently set up CFF for other repositories, such as yours today, I offer now not only a valid initial CFF setup but combine it with a basic bump2version configuration, if applicable for the target repositories.  Projects which do not have a valid CFF setup usually also lack a bump2version configuration.

[CFF](https://github.com/citation-file-format/citation-file-format) is a standard for citing software.  With a valid CITATION.cff, any repository can be cited in papers and theses just like a book or an article.  GitHub renders a "Cite this repository" blob from CITATION.cff configuration files on the project's landing page.  One can copy either an APA citation or a BibTeX entry and paste it as a reference.  As an example, here is the APA citation of the CFF project:

Druskat, S., Spaaks, J. H., Chue Hong, N., Haines, R., Baker, J., Bliven, S., Willighagen, E., Pérez-Suárez, D., & Konovalov, A. (2021). Citation File Format (Version 1.2.0) [Computer software]. https://doi.org/10.5281/zenodo.5171937

Some projects, just like obviously theses as well as some papers (or rather the conferences for which they are submitted), require not only the citation of the consulted literature, one sometimes also needs to cite the used software utilities.  With CFF, maintainers can set up their preferred citation information for their projects.  It also enables the maintenance of a list of contributors like many open source projects provide it.

The suggested initial configuration is derived from the package description of the Python 3 package management system.  You are free to expand and adjust the information as you desire.  I also added an automatic validation, `cffconvert.yml`, which ensures you to always have a valid CITATION.cff.  I added the CITATION.cff to the existing bump2version configuration.  *Please note that also a release date is specified in the CITATION.cff.*

My major use case for the submitted CFF setup is to cite bump2version appropriately when setting it up -- together with CFF -- for other repositories.  It hence helps to ensure and keep a uniform representation of this project.

Regarding the contribution guidelines, the CITATION.cff comes with its own validator which fulfills the requirement of a test case.  The validator considers the CITATION.cff valid.  The other configured GitHub Actions all succeeded, 16 GitHub Action-based tests were ran.  This fulfills, at least in my opinion, the requirement of ensuring the tests to still succeed after making the submitted changes.  No Python code was edited, only the CITATION.cff as well as its validation were created.  The sole file truly edited is the bump2version configuration file which now also tracks the CITATION.cff.  Bumping its version succeeded in a local test.

Please consider to accept this patch in order to ensure bump2version being cited uniformly and in the way you would like to have it cited.