### PR TITLE
Mark 'sign_tags' as a boolean value

### DIFF
--- a/bumpversion/cli.py
+++ b/bumpversion/cli.py
@@ -294,7 +294,7 @@ def _load_configuration(config_file, explicit_config, defaults):
         except NoOptionError:
             pass  # no default value then ;)
 
-    for boolvaluename in ("commit", "tag", "dry_run"):
+    for boolvaluename in ("commit", "tag", "dry_run", "sign_tags"):
         try:
             defaults[boolvaluename] = config.getboolean(
                 "bumpversion", boolvaluename


### PR DESCRIPTION
When passed as a command line option, --(no-)sign-tags is a boolean. When only taken from the configuration, it's a string.

Because of this, string "false" later evaluate to true and signing is attempted and fails.

Working configuration:
~~~
[bumpversion]
current_version = 0.2.8
commit = true
tag = true
message = Bump version from {current_version} to {new_version}
tag_message = Release version {new_version} (previous: {current_version})

[bumpversion:file:pyproject.toml]
~~~

Broken configuration:
~~~
[bumpversion]
current_version = 0.2.8
commit = true
tag = true
sign_tags = false
message = Bump version from {current_version} to {new_version}
tag_message = Release version {new_version} (previous: {current_version})

[bumpversion:file:pyproject.toml]
~~~
