### PR TITLE
Raise exception with error output if CalledProcessError when tagging.

### DIFF
--- a/bumpversion/exceptions.py
+++ b/bumpversion/exceptions.py
@@ -30,3 +30,8 @@ class VersionNotFoundException(BumpVersionException):
 
 class InvalidVersionPartException(BumpVersionException):
     """The specified part (e.g. 'bugfix') was not found"""
+
+
+class TaggingFailureException(BumpVersionException):
+    def __init__(self, message):
+        self.message = message

--- a/bumpversion/vcs.py
+++ b/bumpversion/vcs.py
@@ -7,6 +7,7 @@ from tempfile import NamedTemporaryFile
 from bumpversion.exceptions import (
     WorkingDirectoryIsDirtyException,
     MercurialDoesNotSupportSignedTagsException,
+    TaggingFailureException,
 )
 
 
@@ -135,7 +136,10 @@ class Git(BaseVCS):
             command += ["--sign"]
         if message:
             command += ["--message", message]
-        subprocess.check_output(command)
+        try:
+            subprocess.check_output(command, stderr=subprocess.STDOUT)
+        except subprocess.CalledProcessError as e:
+            raise TaggingFailureException(f"{e.returncode} {e.output.decode()}")
 
 
 class Mercurial(BaseVCS):
@@ -175,4 +179,7 @@ class Mercurial(BaseVCS):
             )
         if message:
             command += ["--message", message]
-        subprocess.check_output(command)
+        try:
+            subprocess.check_output(command, stderr=subprocess.STDOUT)
+        except subprocess.CalledProcessError as e:
+            raise TaggingFailureException(f"{e.returncode} {e.output.decode()}")


### PR DESCRIPTION
Currently if tagging fails (ex: version were changed manually and an old tag was attempted to be re-used), `subprocess.CalledProcessError` is raised without helpful information.

Proposing changing this to raise a custom exception, `TaggingFailureException`, with the `subprocess.CalledProcessError.returncode` and `.output` to help diagnosis the issue.

This will also prevent a successful exit code from occurring if tagging fails, as noted in #224.

Ran `make test` successfully, except for Python 3.5 which is unavailable on the image:
```bash
____________________________________ ERROR collecting tests/test_cli.py ____________________________________
ImportError while importing test module '/code/tests/test_cli.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
.tox/py35/lib/python3.5/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
tests/test_cli.py:15: in <module>
    from testfixtures import LogCapture
.tox/py35/lib/python3.5/site-packages/testfixtures/__init__.py:13: in <module>
    from testfixtures.comparison import (
.tox/py35/lib/python3.5/site-packages/testfixtures/comparison.py:14: in <module>
    from testfixtures.mock import parent_name, mock_call, unittest_mock_call
.tox/py35/lib/python3.5/site-packages/testfixtures/mock.py:47: in <module>
    sys.version_info, backport_version
E   ImportError: Please upgrade Python (you have sys.version_info(major=3, minor=5, micro=7, releaselevel='final', serial=0)) or Mock Backport (You have None)
========================================= short test summary info ==========================================
ERROR tests/test_cli.py
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
============================================= 1 error in 0.30s =============================================
ERROR: InvocationError for command /code/.tox/py35/bin/pytest -r a tests (exited with code 2)
...
_________________________________________________ summary __________________________________________________
ERROR:   py35: commands failed
  py36: commands succeeded
  py37: commands succeeded
  py38: commands succeeded
  pypy3: commands succeeded
```

